### PR TITLE
Added option to serialize JSON as a tree.

### DIFF
--- a/packages/docs/docs/api/useEditor.md
+++ b/packages/docs/docs/api/useEditor.md
@@ -46,7 +46,7 @@ const { connectors, actions, query, ...collected } = useEditor(collector);
     ]],
     ["query", "Query", [
       ["createNode", "(child: React.ReactElement) => Node", "Create a Node from a React element"],
-      ["serialize", "() => String", "Return the current Nodes in JSON"],
+      ["serialize", "(createTree: boolean) => String", "Return the current Nodes in JSON, When set to true, JSON will be returned as a nested tree instead of flat object."],
       ["getOptions", "() => Object", "Get the options specified in the &lt;Editor /&gt; component"],
       ["getDropPlaceholder", 
         "(sourceNodeId: NodeId, targetNodeId: NodeId, pos: {x: number, y: number}, nodesToDOM?: (node: Node) => HTMLElement = node => node.dom)",


### PR DESCRIPTION
closes #13

Adds an option to serialize the JSON output as a tree instead of a flat object.

If the param is set to true, each node will get the `children` attribute. It as an array of objects representing the node children.

I did not remove any attributes so you have all the data you would need to convert it back to the flat object.

Sample: 

```JSON
{
  "type": {"resolvedName":"Container"},
  "isCanvas":true,
  "props":{"background":"#eeeeee","padding":5},
  "displayName":"Canvas",
  "custom":{},
  "nodes":["canvas-wYA65kzm"],
  "children":[{
    "type":{"resolvedName":"Container"},
    "isCanvas":true,
    "props":{"background":"#ffffff","padding":20},
    "displayName":"Canvas",
    "custom":{},
    "index":0,
    "parent":"canvas-ROOT",
    "nodes":["canvas-4ZraoNqU"],
    "children":[{
      "type":{"resolvedName":"Container"},
      "isCanvas":true,
      "props":{"background":"#ffffff","padding":20},
      "displayName":"Canvas",
      "custom":{},
      "index":0,
      "parent":"canvas-wYA65kzm",
      "nodes":["canvas-K37CJhds"],
      "children":[{
        "type":{"resolvedName":"Container"},
        "isCanvas":true,
        "props":{"background":"#ffffff","padding":20},
        "displayName":"Canvas",
        "custom":{},
        "index":0,
        "parent":"canvas-4ZraoNqU",
        "nodes":["canvas-vVWN6zCr"],
        "children":[{
          "type":{"resolvedName":"Container"},
          "isCanvas":true,
          "props":{"background":"#ffffff","padding":20},
          "displayName":"Canvas",
          "custom":{},
          "index":0,
          "parent":"canvas-K37CJhds",
          "nodes":["node-_2a8bFPV"],
          "children":[{
            "type":{"resolvedName":"Button"},
            "props":{"size":"small","variant":"contained","color":"primary","text":"Click me"},
            "displayName":"Button",
            "custom":{},
            "index":0,
            "parent":"canvas-vVWN6zCr"
          }]
        }]
      }]
    }]
  }]
}
```