### PR TITLE
Draft: History - undo/redo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ out
 dist
 lib
 *-*.log
+.vscode

--- a/packages/core/src/render/Frame.tsx
+++ b/packages/core/src/render/Frame.tsx
@@ -23,27 +23,29 @@ export const Frame: React.FC<Frame> = ({ children, json }) => {
   });
 
   useEffect(() => {
-    const { replaceNodes, deserialize } = actions;
+    const { replaceNodes, deserialize, withoutUndo } = actions;
     const { createNode } = query;
 
-    const { initialChildren: children, initialJson: json } = initial.current;
-    if (!json) {
-      const rootCanvas = React.Children.only(children) as React.ReactElement;
-      invariant(
-        rootCanvas.type && rootCanvas.type === Canvas,
-        ERROR_FRAME_IMMEDIATE_NON_CANVAS
-      );
-      let node = createNode(rootCanvas, {
-        id: ROOT_NODE
-      });
-      replaceNodes({
-        [ROOT_NODE]: node
-      });
-    } else {
-      deserialize(json);
-    }
+    withoutUndo(() => {
+      const { initialChildren: children, initialJson: json } = initial.current;
+      if (!json) {
+        const rootCanvas = React.Children.only(children) as React.ReactElement;
+        invariant(
+          rootCanvas.type && rootCanvas.type === Canvas,
+          ERROR_FRAME_IMMEDIATE_NON_CANVAS
+        );
+        let node = createNode(rootCanvas, {
+          id: ROOT_NODE
+        });
+        replaceNodes({
+          [ROOT_NODE]: node
+        });
+      } else {
+        deserialize(json);
+      }
 
-    setRender(<NodeElement id={ROOT_NODE} />);
+      setRender(<NodeElement id={ROOT_NODE} />);
+    });
   }, [actions, query]);
 
   return render;

--- a/packages/examples/landing/components/editor/Viewport/Toolbox.tsx
+++ b/packages/examples/landing/components/editor/Viewport/Toolbox.tsx
@@ -1,52 +1,92 @@
-import React from 'react';
-import {  Canvas, useEditor} from "@craftjs/core";
-import { Container } from '../../selectors/Container';
+import React from "react";
+import { Canvas, useEditor } from "@craftjs/core";
+import { Container } from "../../selectors/Container";
 import { Text } from "../../selectors/Text";
-import { Video } from '../../selectors/Video';
-import { Button } from '../../selectors/Button';
+import { Video } from "../../selectors/Video";
+import { Button } from "../../selectors/Button";
 
-import SquareSvg from '../../../public/icons/toolbox/rectangle.svg';
-import TypeSvg from '../../../public/icons/toolbox/text.svg';
-import YoutubeSvg from '../../../public/icons/toolbox/video-line.svg';
-import ButtonSvg from '../../../public/icons/toolbox/button.svg';
+import SquareSvg from "../../../public/icons/toolbox/rectangle.svg";
+import TypeSvg from "../../../public/icons/toolbox/text.svg";
+import YoutubeSvg from "../../../public/icons/toolbox/video-line.svg";
+import ButtonSvg from "../../../public/icons/toolbox/button.svg";
 
 import styled from "styled-components";
 
-
-const ToolboxDiv = styled.div<{enabled: boolean}>`
+const ToolboxDiv = styled.div<{ enabled: boolean }>`
   transition: 0.4s cubic-bezier(0.19, 1, 0.22, 1);
-  ${props => !props.enabled ? `width: 0;` : ""}
-  ${props => !props.enabled ? `opacity: 0;` : ""}
+  ${props => (!props.enabled ? `width: 0;` : "")}
+  ${props => (!props.enabled ? `opacity: 0;` : "")}
 `;
 
 const Item = styled.div`
   svg {
     width: 22px;
     height: 22px;
-    fill:#707070;
+    fill: #707070;
   }
 `;
 
-
 export const Toolbox = () => {
-  const { enabled, connectors: {create }} = useEditor((state) => ({enabled: state.options.enabled}));
+  const {
+    enabled,
+    connectors: { create },
+    actions
+  } = useEditor(state => ({ enabled: state.options.enabled }));
 
   return (
-    <ToolboxDiv enabled={enabled && enabled} className="toolbox transition w-12 border-r h-screen bg-white">
-      <div className='flex flex-col items-center pt-3'>
-        <div ref={ref => create(ref, <Canvas is={Container} background={{ r: 78, g: 78, b: 78, a: 1 }} color={{ r: 0, g: 0, b: 0, a: 1 }}  height="300px" width="300px"></Canvas>)}>
-          <Item className='m-2 pb-2 cursor-pointer block'><SquareSvg /></Item>
+    <ToolboxDiv
+      enabled={enabled && enabled}
+      className="toolbox transition w-12 border-r h-screen bg-white"
+    >
+      <div className="flex flex-col items-center pt-3">
+        <div
+          ref={ref =>
+            create(
+              ref,
+              <Canvas
+                is={Container}
+                background={{ r: 78, g: 78, b: 78, a: 1 }}
+                color={{ r: 0, g: 0, b: 0, a: 1 }}
+                height="300px"
+                width="300px"
+              ></Canvas>
+            )
+          }
+        >
+          <Item className="m-2 pb-2 cursor-pointer block">
+            <SquareSvg />
+          </Item>
         </div>
-        <div ref={ref => create(ref, <Text fontSize="12" textAlign="left" text="Hi there" />)}>
-          <Item className='m-2 pb-2 cursor-pointer block'><TypeSvg /></Item>
-        </div> 
+        <div
+          ref={ref =>
+            create(ref, <Text fontSize="12" textAlign="left" text="Hi there" />)
+          }
+        >
+          <Item className="m-2 pb-2 cursor-pointer block">
+            <TypeSvg />
+          </Item>
+        </div>
         <div ref={ref => create(ref, <Button />)}>
-          <Item className='m-2 pb-2 cursor-pointer block'><ButtonSvg /></Item>
-        </div> 
+          <Item className="m-2 pb-2 cursor-pointer block">
+            <ButtonSvg />
+          </Item>
+        </div>
         <div ref={ref => create(ref, <Video />)}>
-          <Item className='m-2 pb-2 cursor-pointer block'><YoutubeSvg /></Item>
-        </div> 
+          <Item className="m-2 pb-2 cursor-pointer block">
+            <YoutubeSvg />
+          </Item>
+        </div>
+
+        <div>
+          <button
+            onClick={() => {
+              actions.undo();
+            }}
+          >
+            Undo
+          </button>
+        </div>
       </div>
     </ToolboxDiv>
-  )
-}
+  );
+};

--- a/packages/utils/src/useMethods.ts
+++ b/packages/utils/src/useMethods.ts
@@ -78,7 +78,7 @@ export type QueryCallbacksFor<M extends QueryMethods> = M extends QueryMethods<
   : never;
 
 export function useMethods<S, R extends MethodRecordBase<S>>(
-  methodsOrOptions: Methods<S, R>,
+  methodsOrOptions: MethodsOrOptions<S, R>,
   initialState: any
 ): SubscriberAndCallbacksFor<MethodsOrOptions<S, R>>;
 
@@ -87,7 +87,7 @@ export function useMethods<
   R extends MethodRecordBase<S>,
   Q extends QueryMethods
 >(
-  methodsOrOptions: Methods<S, R, QueryCallbacksFor<Q>>, // methods to manipulate the state
+  methodsOrOptions: MethodsOrOptions<S, R, QueryCallbacksFor<Q>>, // methods to manipulate the state
   initialState: any,
   queryMethods: Q
 ): SubscriberAndCallbacksFor<MethodsOrOptions<S, R>, Q>;


### PR DESCRIPTION
Hi,

last night I tried several ways to implement undo / redo functionality. I'd like to pick your brain on how to best tackle this problem in your opinion.

# Serializing / Deserializing the current state
The easiest way to achieve a undo / redo functionality is to serialize the current state in each action.

```ts
setProp(id: NodeId, cb: (props: any) => void) {
  invariant(state.nodes[id], ERROR_INVALID_NODEID);
  undoStack.push(query.serialize());
  cb(state.nodes[id].data.props);
},
``` 

and then expose a `undo` method and calling deserialize there

```
undo() {
  const undoState = undoStack.pop();
  if (undoState) {
    deserialize(undoState);
  }
},
```

Pros:
- Easy

Cons:
- The history stack can grow very large over time

# Using immer

Since you are using `immer` under the hood I tried to find a way to implement it with `PatchListener`s. But I ran into some problems:

### Adding a patchListener to useMethods
I tried to add a PatchListener to the source. But then all the events will be made `undoable` and I do not think hovered state needs to be undoable 😉.  After filtering out all `"events"` it was way less noisy but still too much. 

### Adding a patchListener in `actions.ts`

We could also add a patchListener directly in e.g. `setProp`

```
setProp(id: NodeId, cb: (props: any) => void) {
  invariant(state.nodes[id], ERROR_INVALID_NODEID);
  state.nodes = produce(state.nodes, (draftedNodes) => {
    cb(draftedNodes[id].data.props);
   }, (patches, inversePatches) => {
     undoStack.push(inversePatches);
  });
},
```

It works for setProp, but it does not work for `deleteNode`:
```
delete(id: NodeId) {
  invariant(id !== ROOT_NODE, "Cannot delete Root node");

  state.nodes = produce(
    state.nodes,
    draftedNodes => {
      const targetNode = draftedNodes[id];
      if (query.node(targetNode.id).isCanvas()) {
        invariant(
          !query.node(targetNode.id).isTopLevelCanvas(),
          "Cannot delete a Canvas that is not a direct child of another Canvas"
        );
        targetNode.data.nodes!.forEach(childId => {
          _("delete")(childId);
        });
      }

      const parentNode = draftedNodes[targetNode.data.parent],
        parentChildNodesId = parentNode.data.nodes!;

      if (parentNode && parentChildNodesId.indexOf(id) > -1) {
        parentChildNodesId.splice(parentChildNodesId.indexOf(id), 1);
      }
      updateEventsNode(state, id, true);
      delete draftedNodes[id];
    },
    (patches, inversePatches) => {
      undoStack.push(inversePatches);
    }
  );
},
```

I think it does not work because `parentChildNodesId.splice` is not part of the inversePatches. I think Immer does not recognize the changes made to the parentChildNodes.

Maybe you have some insights into immer and patches and have an idea?
--- 

I personally lean towards making use of serializing and deserializing. Maybe we could use [JSON-Patch](https://github.com/Starcounter-Jack/JSON-Patch) to calculate the patches needed on the diff between the undo state and the new state.

But I would prefer if history was exposed by `useEditor` directly and not part of the actions. So I tried to pass a history object to the Actions to be able to push to the undoStack.

```
export const Actions = (
  state: EditorState,
  query: QueryCallbacksFor<typeof QueryMethods>
  history: History
) => {
```

But `useMethods` does not allow a third parameter. And I do not know if it is or should be possible to alter `useMethods` to accept a third parameter.

I could also make the undo and redo stack globally available. But that feels code smelly.

# API of History

I propose this API for the `History`  - or maybe call it `UndoManager` 🤔

```
interface History {
  canUndo: () => boolean;
  canRedo: () => boolean;

  undo: () => void;
  redo: () => void;

  withoutUndo: (() => Function);
}
```

With `withoutUndo` you can skip adding items to the history.

```
// this will be undoable
actions.setProp(nodeId, (props) => { props.title = 'New title' });

// this will not be added to the history, thus not be able to be undoable
withUndo(() => {
  actions.delete(parentId);
});
```

--- 

If it's okay for you, I would gladly like to take over the implementation for the history.  


 