### PR TITLE
[WIP] Package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "npmClient": "yarn",
   "private": true,
   "author": "Prev Wong <prevwong@gmail.com>",
   "scripts": {
@@ -7,7 +6,7 @@
     "dev:docs" : "lerna run start --scope docs",
     "dev:all": "run-p dev dev:docs",
     "clean": "lerna run clean --stream",
-    "build": "lerna run build --stream --ignore docs --ignore example-*",
+    "build": "lerna run build --stream --ignore docs --ignore examples",
     "build:all" : "lerna run build --stream",
     "deploy": "./scripts/deploy.sh",
     "release": "run-s lint clean build test release:npm",
@@ -53,12 +52,10 @@
     "ts-jest": "^24.2.0",
     "typescript": "^3.5.1"
   },
-  "workspaces": {
-    "packages": [
-      "packages/*",
-      "packages/examples/*"
-    ]
-  },
+  "workspaces": [
+    "packages/*",
+    "packages/examples/*"
+  ],
   "dependencies": {
     "@babel/preset-typescript": "^7.7.7",
     "all-contributors-cli": "^6.11.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/prevwong/craft.js/issues"
   },
   "dependencies": {
-    "@craftjs/utils": "^0.1.0-beta.1",
+    "@craftjs/utils": "file:../utils",
     "@types/react": "^16.9.11",
     "debounce": "^1.2.0",
     "immer": "^3.1.3",

--- a/packages/examples/basic/package.json
+++ b/packages/examples/basic/package.json
@@ -10,7 +10,7 @@
     "clean": "rimraf lib .next out dist"
   },
   "dependencies": {
-    "@craftjs/core": "^0.1.0-beta.1",
+    "@craftjs/core": "file:../../core",
     "@material-ui/core": "latest",
     "clsx": "latest",
     "copy-to-clipboard": "^3.2.0",

--- a/packages/examples/basic/package.json
+++ b/packages/examples/basic/package.json
@@ -1,7 +1,14 @@
 {
   "name": "example-basic",
   "version": "0.1.0-beta.1",
+  "description": "Basic Page Editor example",
   "private": true,
+  "scripts": {
+    "start": "cross-env NODE_ENV=development next dev -p 3002",
+    "build": "cross-env NODE_ENV=production next build",
+    "export": "next export",
+    "clean": "rimraf lib .next out dist"
+  },
   "dependencies": {
     "@craftjs/core": "^0.1.0-beta.1",
     "@material-ui/core": "latest",
@@ -15,12 +22,6 @@
     "react": "16.11.0",
     "react-contenteditable": "^3.3.3",
     "react-dom": "16.11.0"
-  },
-  "scripts": {
-    "start": "cross-env NODE_ENV=development && next dev -p 3002",
-    "build": "next build",
-    "export": "next export",
-    "clean": "rimraf lib .next out dist"
   },
   "devDependencies": {
     "@zeit/next-css": "^1.0.1",

--- a/packages/examples/landing/package.json
+++ b/packages/examples/landing/package.json
@@ -1,9 +1,10 @@
 {
   "name": "example-landing",
   "version": "0.1.0-beta.1",
+  "description": "Complex example application with Layers panel",
   "private": true,
   "scripts": {
-    "start": "cross-env NODE_ENV=development && next dev -p 3001",
+    "start": "cross-env NODE_ENV=development next dev -p 3001",
     "build": "cross-env NODE_ENV=production next build",
     "export": "next export",
     "clean": "rimraf lib .next out dist"

--- a/packages/examples/landing/package.json
+++ b/packages/examples/landing/package.json
@@ -10,8 +10,8 @@
     "clean": "rimraf lib .next out dist"
   },
   "dependencies": {
-    "@craftjs/core": "^0.1.0-beta.1",
-    "@craftjs/layers": "^0.1.0-beta.1",
+    "@craftjs/core": "file:../../core",
+    "@craftjs/layers": "file:../../layers",
     "@material-ui/core": "^4.5.2",
     "@material-ui/icons": "^4.5.1",
     "@material-ui/styles": "^4.5.2",

--- a/packages/layers/package.json
+++ b/packages/layers/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/prevwong/craft.js/",
   "dependencies": {
-    "@craftjs/utils": "^0.1.0-beta.1",
+    "@craftjs/utils": "file:../utils",
     "immer": "^3.1.3",
     "lodash.isequalwith": "^4.4.0",
     "react-contenteditable": "^3.3.3",
@@ -44,7 +44,7 @@
     "@svgr/rollup": "^4.3.3"
   },
   "peerDependencies": {
-    "@craftjs/core": "^0.1.0-alpha.1",
+    "@craftjs/core": "file:../core",
     "react": "^16.8.0"
   }
 }

--- a/packages/layers/package.json
+++ b/packages/layers/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@craftjs/layers",
+  "version": "0.1.0-beta.1",
   "description": "A Photoshop-like layers panel for your page editor",
   "keywords": [
     "wysiwyg",
@@ -11,7 +12,6 @@
     "web-builder",
     "react"
   ],
-  "version": "0.1.0-beta.1",
   "author": "Prev Wong <prevwong@gmail.com>",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@craftjs/utils",
-  "description": "Utilities used internally across the craft.js monorepo",
-  "private": false,
   "version": "0.1.0-beta.1",
+  "description": "Utilities used internally across the craft.js monorepo",
   "author": "Prev Wong <prevwong@gmail.com>",
   "license": "MIT",
   "main": "./dist/cjs/index.js",


### PR DESCRIPTION
In the order of appearance:

There are some lerna specific keys, which probably don't work from `package.json`. They should be configured in `lerna.json` where they already actually are.


The `ignore` pattern should probably contain the `examples` folder instead?
Have you changed the folder structure in the past?


<s>Shouldn't the intermediary `packages` object be removed from `workspaces`?
I am not fluent with lerna, but when I searched resources to understand it, it seems that the syntax of `package.json` `workspaces` remains managed by `yarn`.
https://medium.com/@jsilvax/a-workflow-guide-for-lerna-with-yarn-workspaces-60f97481149d
https://legacy.yarnpkg.com/blog/2017/08/02/introducing-workspaces/</s>


I moved several blocks in package.json files so that they all follow same structure. It's then easier to read and maintain them.


Does it make sense to link sibling packages internally to save space and to make them use latest/local version of other packages? This is good for local development to be able to test the examples against a local forked version.