### PR TITLE
added missing export of useLayer in packages/layers

### DIFF
--- a/packages/layers/src/index.tsx
+++ b/packages/layers/src/index.tsx
@@ -3,6 +3,7 @@ import { LayerContextProvider } from "./layers/LayerContextProvider";
 import { LayerManagerProvider } from "./manager/LayerManagerProvider";
 import { ROOT_NODE } from "@craftjs/utils";
 import { LayerOptions } from "./interfaces";
+export { useLayer } from "./layers";
 
 export const Layers: React.FC<Partial<LayerOptions>> = ({ ...options }) => {
   return (


### PR DESCRIPTION
In the layers package `useLayer` was not re-exported.  That resulted in project using `@craftjs/layers` not being able to use custom Layer rendering. This is the fix for that.