### PR TITLE
Added events.draggedOver

### DIFF
--- a/packages/core/src/editor/actions.ts
+++ b/packages/core/src/editor/actions.ts
@@ -53,7 +53,8 @@ export const Actions = (
         dragged: null,
         selected: null,
         hovered: null,
-        indicator: null
+        indicator: null,
+        draggedOver: null
       };
     },
     setDOM(id: NodeId, dom: HTMLElement) {
@@ -246,7 +247,8 @@ export const Actions = (
         dragged: null,
         selected: null,
         hovered: null,
-        indicator: null
+        indicator: null,
+        draggedOver: null
       };
       state.nodes = rehydratedNodes;
     }

--- a/packages/core/src/editor/store.tsx
+++ b/packages/core/src/editor/store.tsx
@@ -13,7 +13,8 @@ export const useEditorStore = (options): EditorStore => {
         selected: null,
         dragged: null,
         hovered: null,
-        indicator: null
+        indicator: null,
+        draggedOver: null
       },
       options
     },

--- a/packages/core/src/events/EventManager.tsx
+++ b/packages/core/src/events/EventManager.tsx
@@ -100,6 +100,12 @@ export const EventManager: React.FC = ({ children }) => {
             y: e.clientY
           });
 
+          if (query.node(id).isCanvas()) {
+            setNodeEvent("draggedOver", id);
+          } else {
+            setNodeEvent("draggedOver", query.node(id).get().data.parent);
+          }
+
           if (getPlaceholder) {
             // TODO: Refactor creation of new Nodes via connectors.new()
             // Currently, no Indicator will be displayed if a new Node is dragged to a parent Container that rejects it
@@ -118,6 +124,14 @@ export const EventManager: React.FC = ({ children }) => {
               setIndicator(getPlaceholder);
             } catch (err) {}
           }
+        }
+      ],
+      dragNodeLeave: [
+        "dragleave",
+        (event: MouseEvent, id: NodeId) => {
+          event.preventDefault();
+          event.stopPropagation();
+          setNodeEvent("draggedOver", null);
         }
       ],
       dragNodeEnd: [
@@ -148,6 +162,7 @@ export const EventManager: React.FC = ({ children }) => {
           draggedNode.current = null;
           setIndicator(null);
           setNodeEvent("dragged", null);
+          setNodeEvent("draggedOver", null);
         }
       ]
     };

--- a/packages/core/src/interfaces/nodes.ts
+++ b/packages/core/src/interfaces/nodes.ts
@@ -25,7 +25,7 @@ export type Node = {
 };
 
 export type NodeHelpers = QueryCallbacksFor<typeof QueryMethods>["node"];
-export type NodeEvents = "selected" | "dragged" | "hovered";
+export type NodeEvents = "selected" | "dragged" | "hovered" | "draggedOver";
 export type InternalNode = Pick<Node, "id"> & NodeData;
 export type NodeRefEvent = Record<NodeEvents, boolean>;
 export type NodeRules = {

--- a/packages/examples/landing/components/selectors/Container/index.tsx
+++ b/packages/examples/landing/components/selectors/Container/index.tsx
@@ -1,27 +1,27 @@
 import React from "react";
 import { Resizer } from "../Resizer";
 import { ContainerSettings } from "./ContainerSettings";
+import { useNode } from "@craftjs/core";
 
 export type Container = {
-  background: Record<'r'|'g'|'b'|'a', number>;
-  color: Record<'r' | 'g' | 'b' | 'a', number>,
+  background: Record<"r" | "g" | "b" | "a", number>;
+  color: Record<"r" | "g" | "b" | "a", number>;
   flexDirection: string;
   alignItems: string;
   justifyContent: string;
   fillSpace: string;
   width: string;
   height: string;
-  padding: string[]
-  margin: string[]
+  padding: string[];
+  margin: string[];
   marginTop: number;
   marginLeft: number;
   marginBottom: number;
   marginRight: number;
   shadow: number;
   children: React.ReactNode;
-  radius: number
+  radius: number;
 };
-
 
 const defaultProps = {
   flexDirection: "column",
@@ -36,14 +36,31 @@ const defaultProps = {
   radius: 0,
   width: "100%",
   height: "auto"
-}
+};
 
 export const Container = (props: Partial<Container>) => {
   props = {
     ...defaultProps,
     ...props
-  }
-  const { flexDirection, alignItems, justifyContent, fillSpace, background, color, padding, margin, shadow, radius, children } = props;
+  };
+  const {
+    flexDirection,
+    alignItems,
+    justifyContent,
+    fillSpace,
+    background,
+    color,
+    padding,
+    margin,
+    shadow,
+    radius,
+    children
+  } = props;
+
+  const { isDraggedOver } = useNode(state => ({
+    isDraggedOver: state.events.draggedOver
+  }));
+
   return (
     <Resizer
       propKey={{ width: "width", height: "height" }}
@@ -51,23 +68,26 @@ export const Container = (props: Partial<Container>) => {
         justifyContent,
         flexDirection,
         alignItems,
+        outline: isDraggedOver ? "2px dashed green" : "none",
         background: `rgba(${Object.values(background)})`,
         color: `rgba(${Object.values(color)})`,
         padding: `${padding[0]}px ${padding[1]}px ${padding[2]}px ${padding[3]}px`,
         margin: `${margin[0]}px ${margin[1]}px ${margin[2]}px ${margin[3]}px`,
-        boxShadow: shadow == 0 ? 'none' : `0px 3px 100px ${shadow}px rgba(0, 0, 0, 0.13)`,
+        boxShadow:
+          shadow == 0
+            ? "none"
+            : `0px 3px 100px ${shadow}px rgba(0, 0, 0, 0.13)`,
         borderRadius: `${radius}px`,
         flex: fillSpace == "yes" ? 1 : "unset"
       }}
     >
-        {children}
+      {children}
     </Resizer>
   );
 };
 
-
 Container.craft = {
-  name:"Container",
+  name: "Container",
   defaultProps,
   rules: {
     canDrag: () => true
@@ -75,4 +95,4 @@ Container.craft = {
   related: {
     toolbar: ContainerSettings
   }
-}
+};

--- a/packages/examples/landing/components/selectors/Custom1/index.tsx
+++ b/packages/examples/landing/components/selectors/Custom1/index.tsx
@@ -1,36 +1,68 @@
 import React from "react";
 import { Container } from "../Container";
-import { Canvas, useNode } from "@craftjs/core";
+import { Canvas, useNode, useEditor } from "@craftjs/core";
 import { Button } from "../Button";
 
-export const OnlyButtons = ({children, ...props}) => {
-  const { connectors: {connect}} = useNode();
+export const OnlyButtons = ({ children, ...props }) => {
+  const { draggedNodeId, query } = useEditor(state => ({
+    draggedNodeId: state.events.dragged
+  }));
+  const {
+    connectors: { connect },
+    isDraggedOver
+  } = useNode(state => ({
+    isDraggedOver: state.events.draggedOver
+  }));
+
+  let style: React.CSSProperties = {};
+  if (
+    draggedNodeId &&
+    isDraggedOver &&
+    query.node(draggedNodeId).get().data.type === Button
+  ) {
+    style = {
+      outline: "2px dashed green"
+    };
+  }
+
   return (
-    <div title="only-buttons" ref={connect} className="w-full mt-5" {...props}>
+    <div
+      title="only-buttons"
+      ref={connect}
+      className="w-full mt-5"
+      {...props}
+      style={{ ...style, ...props.style }}
+    >
       {children}
     </div>
-  )
-}
+  );
+};
 
 OnlyButtons.craft = {
   rules: {
-    canMoveIn: (node) => node.data.type == Button
+    canMoveIn: node => node.data.type == Button
   }
-}
+};
 
 export const Custom1 = (props: any) => {
   return (
     <Container {...props}>
-      <h2 className="text-lg px-10 py-5 text-white">I'm a component that only accepts<br/> buttons.</h2>
+      <h2 className="text-lg px-10 py-5 text-white">
+        I'm a component that only accepts
+        <br /> buttons.
+      </h2>
       <Canvas id="wow" is={OnlyButtons}>
         <Button />
-        <Button buttonStyle="outline" color={{r:255,g:255,b:255,a:1}}/>
+        <Button
+          buttonStyle="outline"
+          color={{ r: 255, g: 255, b: 255, a: 1 }}
+        />
       </Canvas>
     </Container>
-  )
-}
+  );
+};
 
 Custom1.craft = {
   ...Container.craft,
   name: "Custom 1"
-}
+};


### PR DESCRIPTION
This is a first attempt to solve #28. But is a draft only.

I started implementing a solution and added `events.draggedOver`. `useNode` now provides a selector for `events.draggedOver: boolean` and `useEditor` now provides a selector for `events.draggedOver: NodeId | null`. Currently this is implementation and example only. I have not added documentation yet because I ran into a problem:

Currently I implemented `draggedOver` like this:
https://github.com/prevwong/craft.js/blob/39350e5da1663a9b23a3060fc4f2e74786976011/packages/core/src/events/EventManager.tsx#L103-L107

It works great for my use case: Adding an outline to the Canvas that the Node will be dropped in.  The problem is that draggedOver will either be the id of the Component the Node is being dragged over if the node is a Canvas or it will be the id of the parent Canvas if the node is not a Canvas. 
It could break the developer's expectation because `draggedOver` will never be true for the component the node is being dragged over if the component is not a Canvas.

I couldn't come up with a good solution that set `draggedOver` to the dragged over `NodeId` while still being able to only add a CSS rule to the parent Canvas.

What do you think @prevwong ? Should we continue with `draggedOver` being either the `NodeId` or the `NodeId` of the parent canvas? Or go with `draggedOver` always being the `NodeId` of the node that is being dragged over?

---
Example Usage in the landing example [Container](https://github.com/prevwong/craft.js/blob/39350e5da1663a9b23a3060fc4f2e74786976011/packages/examples/landing/components/selectors/Container/index.tsx#L60-L87)
Example Usage in the landing example [OnlyButtons](https://github.com/prevwong/craft.js/blob/39350e5da1663a9b23a3060fc4f2e74786976011/packages/examples/landing/components/selectors/Custom1/index.tsx#L7-L39)