### PR TITLE
Improve creation of new elements

### DIFF
--- a/packages/core/src/editor/query.tsx
+++ b/packages/core/src/editor/query.tsx
@@ -147,7 +147,7 @@ export function QueryMethods(Editor: EditorState) {
           .isDraggable(err => (output.error = err));
       }
 
-      // CHeck if source Node is droppable in target
+      // Check if source Node is droppable in target
       _()
         .node(targetParent.id)
         .isDroppable(source, err => (output.error = err));


### PR DESCRIPTION
This PR implements the enhancements described in #10 

Changes made:
- New elements (via `connector.create`) are only added onDragEnd
- `query.getDropPlaceholder` accepts `source` to be either NodeId or Node. 
  - The method is now able to test the acceptance of the newly created source Node (that is not yet in the editor state) against the target Node.

![ezgif com-video-to-gif (6)](https://user-images.githubusercontent.com/16416929/75571941-2c6a1c80-5a95-11ea-9b82-bc01c5f7b3b0.gif)
