### PR TITLE
(#31) Fix reactivity for non-child props on <Canvas />

### DIFF
--- a/packages/core/src/nodes/Canvas.tsx
+++ b/packages/core/src/nodes/Canvas.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { NodeId } from "../interfaces";
 import { mapChildrenToNodes } from "../utils/mapChildrenToNodes";
 import { useInternalNode } from "./useInternalNode";
@@ -32,7 +32,7 @@ export function Canvas<T extends React.ElementType>({
 }: Canvas<T>) {
   const id = props.id;
   const {
-    actions: { add },
+    actions: { add, setProp },
     query,
     inContext
   } = useInternalEditor();
@@ -97,6 +97,22 @@ export function Canvas<T extends React.ElementType>({
 
     setInitialised(true);
   });
+
+  /**
+   *
+   * (https://github.com/prevwong/craft.js/issues/31)
+   * When non-children props on Canvases in User Components are updated, we need to update the prop values in their corresponding Nodes
+   * in order to trigger a re-render
+   */
+  useEffect(() => {
+    if (internalId) {
+      setProp(internalId, nodeProps => {
+        Object.entries(props).forEach(([key, value]) => {
+          nodeProps[key] = value;
+        });
+      });
+    }
+  }, [internalId, props, setProp]);
 
   return (
     <React.Fragment>


### PR DESCRIPTION
This PR closes #31 

Non-`children` prop changes to `<Canvas />` will be cascaded to the underlying User Element:
```jsx
const Container = () => {
  const {connectors: {connect}} = useNode();
  const [background, setBackground] = useState("#fff");

  return (
      <div ref={connect}>
            <a onClick={() => setBackground("#000")}>Click</a>

            // When background changes, MyCanvas will receive its updated value
           <Canvas id="main" is={MyCanvas} background={background}>
                <h3>Hi</h3>
           </Canvas>
      </div>
   )
}

const MyCanvas = ({background}) => {
   const {connectors: {connect}} = useNode();
   return (
     <div ref={connect} style={{background}}>
          {children}
     </div>
   )
}
```