### PR TITLE
fix: allow Subscriber to collect state when created (#52)

### DIFF
--- a/packages/utils/src/Handlers.ts
+++ b/packages/utils/src/Handlers.ts
@@ -50,7 +50,8 @@ class WatchHandler {
         } else {
           this.remove();
         }
-      }
+      },
+      true
     );
   }
 

--- a/packages/utils/src/useMethods.ts
+++ b/packages/utils/src/useMethods.ts
@@ -214,9 +214,12 @@ class Subscriber {
   onChange;
   id;
 
-  constructor(collector, onChange) {
+  constructor(collector, onChange, collectOnCreate = false) {
     this.collector = collector;
     this.onChange = onChange;
+
+    // Collect and run onChange callback when Subscriber is created
+    if (collectOnCreate) this.collect();
   }
 
   collect() {


### PR DESCRIPTION
Closes #52 

Currently, the store's `Subscriber` triggers the collector (and subsequently its callback) when there is a state change. Hence, this causes an issue in #52  with dynamically created elements where a state change is required before the event handlers in the callback can be attached.

This PR enables the collector to be called when the Subscriber is created if the `collectOnCreate` parameter is set to true. 