### PR TITLE
Deep clone target node data nodes during delete

### DIFF
--- a/packages/core/src/editor/actions.ts
+++ b/packages/core/src/editor/actions.ts
@@ -169,9 +169,11 @@ export const Actions = (
           !query.node(targetNode.id).isTopLevelCanvas(),
           "Cannot delete a Canvas that is not a direct child of another Canvas"
         );
-        targetNode.data.nodes!.forEach((childId) => {
-          _("delete")(childId);
-        });
+        if (targetNode.data.nodes) {
+          [...targetNode.data.nodes].forEach((childId) => {
+            _("delete")(childId);
+          });
+        }
       }
 
       const parentNode = state.nodes[targetNode.data.parent],


### PR DESCRIPTION
Fix for #64. Borrowing code from @mresposito's [fork](https://github.com/candulabs/craft.js/blob/master/packages/core/src/editor/actions.ts#L136-L140).
