### PR TITLE
fix: Handlers API

### DIFF
--- a/packages/core/src/events/EventHandlers.ts
+++ b/packages/core/src/events/EventHandlers.ts
@@ -4,7 +4,7 @@ import {
   ConnectorsForHandlers,
   defineEventListener,
   Handlers,
-  CraftEvent,
+  CraftDOMEvent,
 } from '@craftjs/utils';
 import { EditorStore } from '../editor/store';
 
@@ -27,7 +27,7 @@ export class EventHandlers extends Handlers<
         events: [
           defineEventListener(
             'mousedown',
-            (e: CraftEvent<MouseEvent>, id: NodeId) => {
+            (e: CraftDOMEvent<MouseEvent>, id: NodeId) => {
               e.stopCraftPropagation();
               this.store.actions.setNodeEvent('selected', id);
             }
@@ -39,7 +39,7 @@ export class EventHandlers extends Handlers<
         events: [
           defineEventListener(
             'mouseover',
-            (e: CraftEvent<MouseEvent>, id: NodeId) => {
+            (e: CraftDOMEvent<MouseEvent>, id: NodeId) => {
               e.stopCraftPropagation();
               this.store.actions.setNodeEvent('hovered', id);
             }
@@ -48,13 +48,13 @@ export class EventHandlers extends Handlers<
       },
       drop: {
         events: [
-          defineEventListener('dragover', (e: CraftEvent<MouseEvent>) => {
+          defineEventListener('dragover', (e: CraftDOMEvent<MouseEvent>) => {
             e.stopCraftPropagation();
             e.preventDefault();
           }),
           defineEventListener(
             'dragenter',
-            (e: CraftEvent<MouseEvent>, targetId: NodeId) => {
+            (e: CraftDOMEvent<MouseEvent>, targetId: NodeId) => {
               e.stopCraftPropagation();
               e.preventDefault();
 
@@ -95,7 +95,7 @@ export class EventHandlers extends Handlers<
         events: [
           defineEventListener(
             'dragstart',
-            (e: CraftEvent<DragEvent>, id: NodeId) => {
+            (e: CraftDOMEvent<DragEvent>, id: NodeId) => {
               e.stopCraftPropagation();
               this.store.actions.setNodeEvent('dragged', id);
 
@@ -103,7 +103,7 @@ export class EventHandlers extends Handlers<
               EventHandlers.draggedElement = id;
             }
           ),
-          defineEventListener('dragend', (e: CraftEvent<DragEvent>) => {
+          defineEventListener('dragend', (e: CraftDOMEvent<DragEvent>) => {
             e.stopCraftPropagation();
             const onDropElement = (draggedElement, placement) =>
               this.store.actions.move(
@@ -123,7 +123,7 @@ export class EventHandlers extends Handlers<
         events: [
           defineEventListener(
             'dragstart',
-            (e: CraftEvent<DragEvent>, userElement: React.ReactElement) => {
+            (e: CraftDOMEvent<DragEvent>, userElement: React.ReactElement) => {
               e.stopCraftPropagation();
               const tree = this.store.query
                 .parseReactElement(userElement)
@@ -133,7 +133,7 @@ export class EventHandlers extends Handlers<
               EventHandlers.draggedElement = tree;
             }
           ),
-          defineEventListener('dragend', (e: CraftEvent<DragEvent>) => {
+          defineEventListener('dragend', (e: CraftDOMEvent<DragEvent>) => {
             e.stopCraftPropagation();
             const onDropElement = (draggedElement, placement) => {
               const index =

--- a/packages/core/src/events/EventHandlers.ts
+++ b/packages/core/src/events/EventHandlers.ts
@@ -4,6 +4,7 @@ import {
   ConnectorsForHandlers,
   defineEventListener,
   Handlers,
+  CraftEvent,
 } from '@craftjs/utils';
 import { EditorStore } from '../editor/store';
 
@@ -26,10 +27,10 @@ export class EventHandlers extends Handlers<
         events: [
           defineEventListener(
             'mousedown',
-            (e, id: NodeId) => {
+            (e: CraftEvent<MouseEvent>, id: NodeId) => {
+              e.stopCraftPropagation();
               this.store.actions.setNodeEvent('selected', id);
-            },
-            { blocking: true }
+            }
           ),
         ],
       },
@@ -38,25 +39,23 @@ export class EventHandlers extends Handlers<
         events: [
           defineEventListener(
             'mouseover',
-            (e, id: NodeId) => {
+            (e: CraftEvent<MouseEvent>, id: NodeId) => {
+              e.stopCraftPropagation();
               this.store.actions.setNodeEvent('hovered', id);
-            },
-            { blocking: true }
+            }
           ),
         ],
       },
       drop: {
         events: [
-          defineEventListener(
-            'dragover',
-            (e: MouseEvent) => {
-              e.preventDefault();
-            },
-            { blocking: true }
-          ),
+          defineEventListener('dragover', (e: CraftEvent<MouseEvent>) => {
+            e.stopCraftPropagation();
+            e.preventDefault();
+          }),
           defineEventListener(
             'dragenter',
-            (e: MouseEvent, targetId: NodeId) => {
+            (e: CraftEvent<MouseEvent>, targetId: NodeId) => {
+              e.stopCraftPropagation();
               e.preventDefault();
 
               const draggedElement = EventHandlers.draggedElement as NodeTree;
@@ -79,8 +78,7 @@ export class EventHandlers extends Handlers<
               }
               this.store.actions.setIndicator(indicator);
               EventHandlers.events = { indicator };
-            },
-            { blocking: true }
+            }
           ),
         ],
       },
@@ -97,27 +95,24 @@ export class EventHandlers extends Handlers<
         events: [
           defineEventListener(
             'dragstart',
-            (e: DragEvent, id: NodeId) => {
+            (e: CraftEvent<DragEvent>, id: NodeId) => {
+              e.stopCraftPropagation();
               this.store.actions.setNodeEvent('dragged', id);
 
               EventHandlers.draggedElementShadow = createShadow(e);
               EventHandlers.draggedElement = id;
-            },
-            { blocking: true }
+            }
           ),
-          defineEventListener(
-            'dragend',
-            (e: DragEvent) => {
-              const onDropElement = (draggedElement, placement) =>
-                this.store.actions.move(
-                  draggedElement as NodeId,
-                  placement.parent.id,
-                  placement.index + (placement.where === 'after' ? 1 : 0)
-                );
-              this.dropElement(onDropElement);
-            },
-            { blocking: true }
-          ),
+          defineEventListener('dragend', (e: CraftEvent<DragEvent>) => {
+            e.stopCraftPropagation();
+            const onDropElement = (draggedElement, placement) =>
+              this.store.actions.move(
+                draggedElement as NodeId,
+                placement.parent.id,
+                placement.index + (placement.where === 'after' ? 1 : 0)
+              );
+            this.dropElement(onDropElement);
+          }),
         ],
       },
       create: {
@@ -128,32 +123,29 @@ export class EventHandlers extends Handlers<
         events: [
           defineEventListener(
             'dragstart',
-            (e: DragEvent, userElement: React.ReactElement) => {
+            (e: CraftEvent<DragEvent>, userElement: React.ReactElement) => {
+              e.stopCraftPropagation();
               const tree = this.store.query
                 .parseReactElement(userElement)
                 .toNodeTree();
 
               EventHandlers.draggedElementShadow = createShadow(e);
               EventHandlers.draggedElement = tree;
-            },
-            { blocking: true }
+            }
           ),
-          defineEventListener(
-            'dragend',
-            (e: DragEvent) => {
-              const onDropElement = (draggedElement, placement) => {
-                const index =
-                  placement.index + (placement.where === 'after' ? 1 : 0);
-                this.store.actions.addNodeTree(
-                  draggedElement,
-                  placement.parent.id,
-                  index
-                );
-              };
-              this.dropElement(onDropElement);
-            },
-            { blocking: true }
-          ),
+          defineEventListener('dragend', (e: CraftEvent<DragEvent>) => {
+            e.stopCraftPropagation();
+            const onDropElement = (draggedElement, placement) => {
+              const index =
+                placement.index + (placement.where === 'after' ? 1 : 0);
+              this.store.actions.addNodeTree(
+                draggedElement,
+                placement.parent.id,
+                index
+              );
+            };
+            this.dropElement(onDropElement);
+          }),
         ],
       },
     };

--- a/packages/core/src/events/tests/EventHandlers.test.ts
+++ b/packages/core/src/events/tests/EventHandlers.test.ts
@@ -15,7 +15,13 @@ describe('EventHandlers', () => {
   const callHandler = (events, name) => getHandler(events, name)[1];
   const shadow = 'a shadow';
 
-  let e;
+  let e = {
+    preventDefault: jest.fn(),
+    stopImmediatePropagation: jest.fn(),
+    stopCraftPropagation: jest.fn(),
+    clientX: 0,
+    clientY: 0,
+  };
   let eventHandlers;
   let store;
   let actions;
@@ -28,10 +34,6 @@ describe('EventHandlers', () => {
   }));
 
   beforeEach(() => {
-    e = {
-      preventDefault: jest.fn(),
-    };
-
     createShadow = jest.fn().mockImplementation(() => shadow);
 
     EventHandlers.draggedElement = undefined;
@@ -99,7 +101,6 @@ describe('EventHandlers', () => {
     let drop;
 
     beforeEach(() => {
-      e = { preventDefault: jest.fn() };
       drop = eventHandlers.handlers().drop;
     });
     it('should contain two events, dragover and dragenter', () => {

--- a/packages/utils/src/Handlers.ts
+++ b/packages/utils/src/Handlers.ts
@@ -1,18 +1,18 @@
 import { wrapHookToRecognizeElement, Connector } from './wrapConnectorHooks';
 
-export type CraftEvent<T extends Event> = T & {
+export type CraftDOMEvent<T extends Event> = T & {
   stopCraftPropagation: () => void;
 };
 
 export type CraftEventListener = [
   string,
-  (e: CraftEvent<Event>, opts: any) => void,
+  (e: CraftDOMEvent<Event>, opts: any) => void,
   boolean
 ];
 
 export const defineEventListener = (
   name: string,
-  handler: (e: CraftEvent<Event>, payload: any) => void,
+  handler: (e: CraftDOMEvent<Event>, payload: any) => void,
   capture?: boolean
 ): CraftEventListener => [name, handler, capture];
 


### PR DESCRIPTION
- Improvements to PR #85 
  - Expose `e.stopCraftPropagation` rather than passing a flag. This is so we can maintain API similarity with DOM `addEventListener` 
- Fix bug that causes Handlers to work incorrectly when the editor is disabled and re-enabled again
