### PR TITLE
fix: handle propagation by matching descendant

### DIFF
--- a/packages/core/src/events/EventHandlers.ts
+++ b/packages/core/src/events/EventHandlers.ts
@@ -28,7 +28,7 @@ export class EventHandlers extends Handlers<
           defineEventListener(
             'mousedown',
             (e: CraftDOMEvent<MouseEvent>, id: NodeId) => {
-              e.stopCraftPropagation();
+              e.craft.stopPropagation();
               this.store.actions.setNodeEvent('selected', id);
             }
           ),
@@ -40,7 +40,7 @@ export class EventHandlers extends Handlers<
           defineEventListener(
             'mouseover',
             (e: CraftDOMEvent<MouseEvent>, id: NodeId) => {
-              e.stopCraftPropagation();
+              e.craft.stopPropagation();
               this.store.actions.setNodeEvent('hovered', id);
             }
           ),
@@ -49,13 +49,13 @@ export class EventHandlers extends Handlers<
       drop: {
         events: [
           defineEventListener('dragover', (e: CraftDOMEvent<MouseEvent>) => {
-            e.stopCraftPropagation();
+            e.craft.stopPropagation();
             e.preventDefault();
           }),
           defineEventListener(
             'dragenter',
             (e: CraftDOMEvent<MouseEvent>, targetId: NodeId) => {
-              e.stopCraftPropagation();
+              e.craft.stopPropagation();
               e.preventDefault();
 
               const draggedElement = EventHandlers.draggedElement as NodeTree;
@@ -96,7 +96,7 @@ export class EventHandlers extends Handlers<
           defineEventListener(
             'dragstart',
             (e: CraftDOMEvent<DragEvent>, id: NodeId) => {
-              e.stopCraftPropagation();
+              e.craft.stopPropagation();
               this.store.actions.setNodeEvent('dragged', id);
 
               EventHandlers.draggedElementShadow = createShadow(e);
@@ -104,7 +104,7 @@ export class EventHandlers extends Handlers<
             }
           ),
           defineEventListener('dragend', (e: CraftDOMEvent<DragEvent>) => {
-            e.stopCraftPropagation();
+            e.craft.stopPropagation();
             const onDropElement = (draggedElement, placement) =>
               this.store.actions.move(
                 draggedElement as NodeId,
@@ -124,7 +124,7 @@ export class EventHandlers extends Handlers<
           defineEventListener(
             'dragstart',
             (e: CraftDOMEvent<DragEvent>, userElement: React.ReactElement) => {
-              e.stopCraftPropagation();
+              e.craft.stopPropagation();
               const tree = this.store.query
                 .parseReactElement(userElement)
                 .toNodeTree();
@@ -134,7 +134,7 @@ export class EventHandlers extends Handlers<
             }
           ),
           defineEventListener('dragend', (e: CraftDOMEvent<DragEvent>) => {
-            e.stopCraftPropagation();
+            e.craft.stopPropagation();
             const onDropElement = (draggedElement, placement) => {
               const index =
                 placement.index + (placement.where === 'after' ? 1 : 0);

--- a/packages/core/src/events/tests/EventHandlers.test.ts
+++ b/packages/core/src/events/tests/EventHandlers.test.ts
@@ -18,7 +18,9 @@ describe('EventHandlers', () => {
   let e = {
     preventDefault: jest.fn(),
     stopImmediatePropagation: jest.fn(),
-    stopCraftPropagation: jest.fn(),
+    craft: {
+      stopPropagation: jest.fn(),
+    },
     clientX: 0,
     clientY: 0,
   };

--- a/packages/utils/src/Handlers.ts
+++ b/packages/utils/src/Handlers.ts
@@ -47,7 +47,7 @@ const isEventBlockedByDescendant = (e, eventName, el) => {
   for (let i = 0; i < blockingElements.length; i++) {
     const blockingElement = blockingElements[i];
 
-    if (el.contains(blockingElement)) {
+    if (el !== blockingElement && el.contains(blockingElement)) {
       return true;
     }
   }

--- a/packages/utils/src/Handlers.ts
+++ b/packages/utils/src/Handlers.ts
@@ -47,8 +47,6 @@ const isEventBlockedByDescendant = (e, eventName, el) => {
   for (let i = 0; i < blockingElements.length; i++) {
     const blockingElement = blockingElements[i];
 
-    // If the specified element is an ancestor of one of the child elements
-    // that prevented propagation of the specified event
     if (el.contains(blockingElement)) {
       return true;
     }


### PR DESCRIPTION
Further fixes to make `stopPropagation` replicate its native behavior

- Disable only specific event from firing on ancestors. The existing approach disables any event on the parent(s) to fire. Instead, it should only disable events that are of the same name as the handler where `stopPropagation` is called.
- Disable events only on the ancestors of the element that is preventing propagation. The existing approach also prevents non-ancestor elements with the same handler/connector from firing.

