### PR TITLE
feat: add parseFreshNode

### DIFF
--- a/packages/core/src/editor/tests/query.test.tsx
+++ b/packages/core/src/editor/tests/query.test.tsx
@@ -8,12 +8,15 @@ import {
   secondaryButton,
   documentWithCardState,
 } from '../../tests/fixtures';
+import { createNode } from '../../utils/createNode';
 import { parseNodeFromJSX } from '../../utils/parseNodeFromJSX';
 import { deserializeNode } from '../../utils/deserializeNode';
-import { SerializedNode } from '@craftjs/core';
 
 jest.mock('../../utils/resolveComponent', () => ({
   resolveComponent: () => null,
+}));
+jest.mock('../../utils/createNode', () => ({
+  createNode: () => null,
 }));
 jest.mock('../../utils/parseNodeFromJSX', () => ({
   parseNodeFromJSX: () => null,
@@ -35,36 +38,61 @@ describe('query', () => {
   describe('parseSerializedNode', () => {
     describe('toNode', () => {
       let data = {
+        type: 'h2',
         props: { className: 'hello' },
         nodes: [],
         custom: {},
         isCanvas: false,
         parent: null,
+
         displayName: 'h2',
         hidden: false,
       };
-      let serializedNode: SerializedNode = {
-        type: 'h2',
-        ...data,
-      };
 
       beforeEach(() => {
-        deserializeNode = jest.fn().mockImplementation(() => serializedNode);
-        parseNodeFromJSX = jest.fn();
+        deserializeNode = jest.fn().mockImplementation(() => data);
+        createNode = jest.fn().mockImplementation(() => null);
 
-        query.parseSerializedNode(serializedNode).toNode();
+        query.parseSerializedNode(data).toNode();
       });
 
       it('should call deserializeNode', () => {
-        expect(deserializeNode).toBeCalledWith(
-          serializedNode,
-          state.options.resolver
-        );
+        expect(deserializeNode).toBeCalledWith(data, state.options.resolver);
       });
 
       it('should call parseNodeFromJSX', () => {
-        expect(parseNodeFromJSX).toBeCalledWith(
-          React.createElement('h2', data.props),
+        expect(createNode).toHaveBeenCalledWith(
+          {
+            data,
+          },
+          expect.any(Function)
+        );
+      });
+    });
+  });
+
+  describe('parseFreshNode', () => {
+    describe('toNode', () => {
+      let data = {
+        type: 'h1',
+      };
+
+      beforeEach(() => {
+        createNode = jest.fn().mockImplementation(() => null);
+        query
+          .parseFreshNode({
+            data: {
+              type: 'h1',
+            },
+          })
+          .toNode();
+      });
+
+      it('should call createNode', () => {
+        expect(createNode).toHaveBeenCalledWith(
+          {
+            data,
+          },
           expect.any(Function)
         );
       });
@@ -72,10 +100,6 @@ describe('query', () => {
   });
 
   describe('parseReactElement', () => {
-    describe('toNodeTree', () => {});
-  });
-
-  describe('parseNodeFromReactNode', () => {
     let tree;
     const node = <h1>Hello</h1>;
     const name = 'Document';

--- a/packages/core/src/interfaces/nodes.ts
+++ b/packages/core/src/interfaces/nodes.ts
@@ -55,6 +55,11 @@ export type NodeData = {
   _childCanvas?: Record<string, NodeId>; // TODO: Deprecate in favour of linkedNodes
 };
 
+export type FreshNode = {
+  id?: NodeId;
+  data: Partial<NodeData> & Required<Pick<NodeData, 'type'>>;
+};
+
 export type ReduceCompType =
   | string
   | {

--- a/packages/core/src/utils/createNode.ts
+++ b/packages/core/src/utils/createNode.ts
@@ -1,0 +1,125 @@
+import React from 'react';
+import { NodeData, Node, FreshNode } from '../interfaces';
+import { produce } from 'immer';
+import { Canvas, deprecateCanvasComponent } from '../nodes/Canvas';
+import {
+  defaultElementProps,
+  Element,
+  elementPropToNodeData,
+} from '../nodes/Element';
+import { NodeProvider } from '../nodes/NodeContext';
+import { getRandomNodeId } from './getRandomNodeId';
+
+export function createNode(
+  newNode: FreshNode,
+  normalize?: (node: Node) => void
+) {
+  let actualType = newNode.data.type as any;
+  let id = newNode.id || getRandomNodeId();
+
+  return produce({}, (node: Node) => {
+    node.id = id;
+    node._hydrationTimestamp = Date.now();
+
+    node.data = {
+      type: actualType,
+      props: { ...newNode.data.props },
+      name:
+        typeof actualType == 'string' ? actualType : (actualType as any).name,
+      displayName:
+        typeof actualType == 'string' ? actualType : (actualType as any).name,
+      custom: {},
+      isCanvas: false,
+      hidden: false,
+      ...newNode.data,
+    } as NodeData;
+
+    node.related = {};
+
+    node.events = {
+      selected: false,
+      dragged: false,
+      hovered: false,
+    };
+
+    node.rules = {
+      canDrag: () => true,
+      canDrop: () => true,
+      canMoveIn: () => true,
+      canMoveOut: () => true,
+      ...((actualType.craft && actualType.craft.rules) || {}),
+    };
+
+    // @ts-ignore
+    if (node.data.type === Element || node.data.type === Canvas) {
+      let usingDeprecatedCanvas = node.data.type === Canvas;
+      const mergedProps = {
+        ...defaultElementProps,
+        ...node.data.props,
+      };
+
+      Object.keys(defaultElementProps).forEach((key) => {
+        node.data[elementPropToNodeData[key] || key] = mergedProps[key];
+        delete node.data.props[key];
+      });
+
+      actualType = node.data.type;
+
+      if (usingDeprecatedCanvas) {
+        node.data.isCanvas = true;
+        deprecateCanvasComponent();
+      }
+    }
+
+    if (normalize) {
+      normalize(node);
+    }
+
+    if (actualType.craft) {
+      node.data.props = {
+        ...(actualType.craft.props || actualType.craft.defaultProps || {}),
+        ...node.data.props,
+      };
+
+      const displayName = actualType.craft.displayName || actualType.craft.name;
+      if (displayName) {
+        node.data.displayName = displayName;
+      }
+
+      if (actualType.craft.isCanvas) {
+        node.data.isCanvas = node.data.isCanvas || actualType.craft.isCanvas;
+      }
+
+      if (actualType.craft.rules) {
+        Object.keys(actualType.craft.rules).forEach((key) => {
+          if (['canDrag', 'canDrop', 'canMoveIn', 'canMoveOut'].includes(key)) {
+            node.rules[key] = actualType.craft.rules[key];
+          }
+        });
+      }
+
+      if (actualType.craft.custom) {
+        node.data.custom = {
+          ...actualType.craft.custom,
+          ...node.data.custom,
+        };
+      }
+
+      if (actualType.craft.related) {
+        node.related = {};
+        const relatedNodeContext = {
+          id: node.id,
+          related: true,
+        };
+        Object.keys(actualType.craft.related).forEach((comp) => {
+          node.related[comp] = () =>
+            React.createElement(
+              NodeProvider,
+              relatedNodeContext,
+              React.createElement(actualType.craft.related[comp])
+            );
+        });
+      }
+    }
+  }) as Node;
+}

--- a/packages/core/src/utils/parseNodeFromJSX.tsx
+++ b/packages/core/src/utils/parseNodeFromJSX.tsx
@@ -1,14 +1,6 @@
 import React, { Fragment } from 'react';
-import { NodeData, Node } from '../interfaces';
-import { produce } from 'immer';
-import { Canvas, deprecateCanvasComponent } from '../nodes/Canvas';
-import {
-  defaultElementProps,
-  Element,
-  elementPropToNodeData,
-} from '../nodes/Element';
-import { NodeProvider } from '../nodes/NodeContext';
-import { getRandomNodeId } from './getRandomNodeId';
+import { Node } from '../interfaces';
+import { createNode } from './createNode';
 
 export function parseNodeFromJSX(
   jsx: React.ReactElement | string,
@@ -22,106 +14,17 @@ export function parseNodeFromJSX(
 
   let actualType = element.type as any;
 
-  let id = getRandomNodeId();
-
-  return produce({}, (node: Node) => {
-    node.id = id;
-    node._hydrationTimestamp = Date.now();
-
-    node.data = {
-      type: actualType,
-      props: { ...element.props },
-      name:
-        typeof actualType == 'string' ? actualType : (actualType as any).name,
-      displayName:
-        typeof actualType == 'string' ? actualType : (actualType as any).name,
-      custom: {},
-      hidden: false,
-    } as NodeData;
-
-    node.related = {};
-
-    node.events = {
-      selected: false,
-      dragged: false,
-      hovered: false,
-    };
-
-    node.rules = {
-      canDrag: () => true,
-      canDrop: () => true,
-      canMoveIn: () => true,
-      canMoveOut: () => true,
-      ...((actualType.craft && actualType.craft.rules) || {}),
-    };
-
-    // @ts-ignore
-    if (node.data.type === Element || node.data.type === Canvas) {
-      let usingDeprecatedCanvas = node.data.type === Canvas;
-      const mergedProps = {
-        ...defaultElementProps,
-        ...node.data.props,
-      };
-
-      Object.keys(defaultElementProps).forEach((key) => {
-        node.data[elementPropToNodeData[key] || key] = mergedProps[key];
-        delete node.data.props[key];
-      });
-
-      actualType = node.data.type;
-
-      if (usingDeprecatedCanvas) {
-        node.data.isCanvas = true;
-        deprecateCanvasComponent();
+  return createNode(
+    {
+      data: {
+        type: actualType,
+        props: { ...element.props },
+      },
+    },
+    (node) => {
+      if (normalize) {
+        normalize(node, element);
       }
     }
-
-    if (normalize) {
-      normalize(node, element as React.ReactElement);
-    }
-
-    if (actualType.craft) {
-      node.data.props = {
-        ...(actualType.craft.props || actualType.craft.defaultProps || {}),
-        ...node.data.props,
-      };
-
-      const displayName = actualType.craft.displayName || actualType.craft.name;
-      if (displayName) {
-        node.data.displayName = displayName;
-      }
-
-      if (actualType.craft.isCanvas) {
-        node.data.isCanvas = node.data.isCanvas || actualType.craft.isCanvas;
-      }
-
-      if (actualType.craft.rules) {
-        Object.keys(actualType.craft.rules).forEach((key) => {
-          if (['canDrag', 'canDrop', 'canMoveIn', 'canMoveOut'].includes(key)) {
-            node.rules[key] = actualType.craft.rules[key];
-          }
-        });
-      }
-
-      if (actualType.craft.custom) {
-        node.data.custom = node.data.custom || actualType.craft.custom;
-      }
-
-      if (actualType.craft.related) {
-        node.related = {};
-        const relatedNodeContext = {
-          id: node.id,
-          related: true,
-        };
-        Object.keys(actualType.craft.related).forEach((comp) => {
-          node.related[comp] = () =>
-            React.createElement(
-              NodeProvider,
-              relatedNodeContext,
-              React.createElement(actualType.craft.related[comp])
-            );
-        });
-      }
-    }
-  }) as Node;
+  );
 }

--- a/packages/core/src/utils/tests/createNode.test.tsx
+++ b/packages/core/src/utils/tests/createNode.test.tsx
@@ -1,0 +1,109 @@
+import { createNode } from '../createNode';
+import { createTestNode } from '../createTestNode';
+
+const expectNode = (node, testData) => {
+  const type = node.data.type;
+  const isUserComponent = typeof type === 'function' && !!type.craft;
+
+  const match = createTestNode(node.id, {
+    ...testData,
+    props: isUserComponent
+      ? { ...(type.craft.defaultProps || {}), ...testData.props }
+      : testData.props || {},
+    custom: isUserComponent ? type.craft.custom : {},
+    name: typeof type === 'string' ? type : type.name,
+    displayName: typeof type === 'string' ? type : type.name,
+  });
+
+  expect(node.data).toEqual(match.data);
+
+  if (!isUserComponent) {
+    return;
+  }
+
+  if (type.craft.rules) {
+    Object.keys(type.craft.rules).forEach((name) => {
+      expect(node.rules[name]).toEqual(type.craft.rules[name]);
+    });
+  }
+
+  if (type.craft.related) {
+    Object.keys(type.craft.related).forEach((name) => {
+      expect(node.related[name]).toEqual(expect.any(Function));
+    });
+  }
+};
+
+describe('createNode', () => {
+  const props = { href: 'href' };
+
+  describe('Returns correct type and props', () => {
+    it('should transform a link correctly', () => {
+      const data = {
+        type: 'a',
+        props,
+      };
+
+      const node = createNode({
+        data,
+      });
+
+      expectNode(node, data);
+    });
+    it('should normalise data correctly', () => {
+      const extraData = { props: { style: 'purple' } };
+
+      const { data } = createNode(
+        {
+          data: { type: 'button', props },
+        },
+        (node) => {
+          node.data.props = {
+            ...node.data.props,
+            ...extraData.props,
+          };
+        }
+      );
+
+      expect({ type: data.type, props: data.props }).toEqual({
+        type: 'button',
+        props: {
+          ...props,
+          ...extraData.props,
+        },
+      });
+    });
+
+    describe('when a User Component is passed', () => {
+      const Component = () => {};
+      Component.craft = {
+        custom: {
+          css: {
+            background: '#fff',
+          },
+        },
+        rules: {
+          canMoveIn: () => false,
+        },
+        defaultProps: {
+          text: '#000',
+        },
+        related: {
+          settings: () => {},
+        },
+      };
+
+      it('should return node with correct type and user component config', () => {
+        const data = {
+          type: Component,
+        };
+
+        const node = createNode({
+          data,
+        });
+
+        expectNode(node, data);
+      });
+    });
+  });
+});

--- a/packages/core/src/utils/tests/parseNodeFromJSX.test.tsx
+++ b/packages/core/src/utils/tests/parseNodeFromJSX.test.tsx
@@ -1,65 +1,70 @@
 import React, { Fragment } from 'react';
 import { parseNodeFromJSX } from '../parseNodeFromJSX';
+import { createNode } from '../createNode';
 
 const Component = ({ href }) => <a href={href}>Hi</a>;
 
 describe('parseNodeFromJSX', () => {
   const props = { href: 'href' };
 
+  beforeEach(() => {
+    createNode = jest.fn();
+  });
+
   describe('Returns correct type and props', () => {
     it('should transform a link correctly', () => {
       // eslint-disable-next-line  jsx-a11y/anchor-has-content
-      const { data } = parseNodeFromJSX(<a {...props} />);
+      parseNodeFromJSX(<a {...props} />);
 
-      expect({ type: data.type, props: data.props }).toEqual({
-        type: 'a',
-        props,
-      });
-    });
-    it('should normalise data correctly', () => {
-      const extraData = { props: { style: 'purple' } };
-      const { data } = parseNodeFromJSX(
-        <button {...(props as any)} />,
-        (node) => {
-          node.data.props = {
-            ...node.data.props,
-            ...extraData.props,
-          };
-        }
-      );
-
-      expect({ type: data.type, props: data.props }).toEqual({
-        type: 'button',
-        props: {
-          ...props,
-          ...extraData.props,
+      expect(createNode).toBeCalledWith(
+        {
+          data: {
+            type: 'a',
+            props,
+          },
         },
-      });
+        expect.any(Function)
+      );
     });
     it('should be able to parse a component correctly', () => {
-      const { data } = parseNodeFromJSX(<Component {...props} />);
+      parseNodeFromJSX(<Component {...props} />);
 
-      expect({ type: data.type, props: data.props }).toEqual({
-        type: Component,
-        props,
-      });
+      expect(createNode).toBeCalledWith(
+        {
+          data: {
+            type: Component,
+            props,
+          },
+        },
+        expect.any(Function)
+      );
     });
     it('should transform text with `div` correctly', () => {
-      const { data } = parseNodeFromJSX('div');
-      expect({ type: data.type, props: data.props }).toEqual({
-        type: Fragment,
-        props: { children: 'div' },
-      });
+      parseNodeFromJSX('div');
+
+      expect(createNode).toBeCalledWith(
+        {
+          data: {
+            type: Fragment,
+            props: { children: 'div' },
+          },
+        },
+        expect.any(Function)
+      );
     });
     it('should be able to parse plain text correctly', () => {
       const text = 'hello there';
-      const { data } = parseNodeFromJSX(text);
-      expect({ type: data.type, props: data.props }).toEqual({
-        type: Fragment,
-        props: {
-          children: text,
+      parseNodeFromJSX(text);
+
+      expect(createNode).toBeCalledWith(
+        {
+          data: {
+            type: Fragment,
+            props: { children: text },
+          },
         },
-      });
+        expect.any(Function)
+      );
     });
   });
 });

--- a/packages/docs/docs/api/useEditor.md
+++ b/packages/docs/docs/api/useEditor.md
@@ -54,11 +54,14 @@ const { connectors, actions, query, ...collected } = useEditor(collector);
       ],
       ["node", "(id: NodeId) => NodeHelpers", "Returns an object containing helper methods to describe the specified Node. Click <a href='/craft.js/r/docs/api/helpers/'>here</a> for more information."],
       ["parseReactElement", "(element: React.ReactElement) => Object", [
-        ["toNodeTree", "() => NodeTree", "Parses a given React element into a NodeTree"]
+        ["toNodeTree", "() => NodeTree", "Parse a given React element into a NodeTree"]
       ]],
       ["parseSerializedNode", "(node: SerializedNode) => Object", [
-        ["toNode", "() => Node", "Parses a serialized Node back into it's full Node form"]
-      ]]
+        ["toNode", "() => Node", "Parse a serialized Node back into it's full Node form"]
+      ]],
+      ["parseFreshNode", "(node: FreshNode) => Object", [
+        ["toNode", "() => Node", "Parse a fresh/new Node object into it's full Node form, ensuring all properties of a Node is correctly initialised. This is useful when you need to create a new Node"]
+      ]],
     ]],
     ["inContext", "boolean", "Returns false if the component is rendered outside of the &lt;Editor /&gt;. This is useful if you are designing a general component that you also wish to use outside of Craft.js."],
     ["...collected", "Collected", "The collected values returned from the collector"]
@@ -104,6 +107,44 @@ const Example = () => {
     >
       Update
     </a>
+  )
+}
+```
+
+### Creating new Nodes
+```tsx
+import {useEditor} from "@craftjs/core";
+
+const Example = () => {
+  const { query, actions } = useEditor((state, query) => ({
+    hoveredNodeId: state.events.hovered
+  }));
+
+  return (
+    <div>
+      <a onClick={() => {
+        const nodeTree = query.parseReactElement(<h2>Hi</h2>).toNodeTree();
+        actions.addNodeTree(nodeTree);
+      }}>
+        Add a new Node from a React Element
+      </a>
+        
+      <a onClick={() => {
+        // A fresh Node is a partial Node object
+        // where only the data.type property is required
+        const freshNode = {
+            data: {
+                type: 'h1'
+            }
+        };
+        
+        // Create a new valid Node object from the fresh Node
+        const node = query.parseFreshNode(freshNode).toNode();
+        actions.add(node, 'ROOT');
+      }}>
+        Add a new Node from a Node object
+      </a>
+    </div>
   )
 }
 ```
@@ -162,27 +203,6 @@ const Example = () => {
   )
 }
 ```
-
-### Creating and Adding a new Node
-```tsx
-import {useEditor} from "@craftjs/core";
-
-const Example = () => {
-  const { query, actions } = useEditor((state, query) => ({
-    hoveredNodeId: state.events.hovered
-  }));
-
-  return (
-    <div>
-      <a onClick={() => {
-        const node = query.parseReactElement(<h2>Hi</h2>).toNodeTree();
-        actions.addNodeTree(node);
-      }}>Click me to add a new Node</a>
-    </div>
-  )
-}
-```
-
 
 ### Getting the currently selected Node's descendants
 > Query methods are also accessible from within the collector function.


### PR DESCRIPTION
- Add `parseFreshNode` to allow developers to easily create new Node objects
- Fix `.custom` not loading default values correctly