### PR TITLE
show info is throwing errors

### DIFF
--- a/packages/examples/landing/components/selectors/Video/index.tsx
+++ b/packages/examples/landing/components/selectors/Video/index.tsx
@@ -35,7 +35,6 @@ export const Video = (props: any) => {
         opts={{
           width: '100%',
           height: '100%',
-          showinfo: 0,
         }}
       />
     </YoutubeDiv>


### PR DESCRIPTION
removing it resolves the issue.

```[ error ] ERROR in /Users/ichenwu/code/landing/components/selectors/Video/index.tsx
38:11 No overload matches this call.
  Overload 1 of 2, '(props: Readonly<YouTubeProps>): YouTube', gave the following error.
    Type '{ width: string; height: string; showinfo: number; }' is not assignable to type 'Options'.
      Object literal may only specify known properties, and 'showinfo' does not exist in type 'Options'.
  Overload 2 of 2, '(props: YouTubeProps, context?: any): YouTube', gave the following error.
    Type '{ width: string; height: string; showinfo: number; }' is not assignable to type 'Options'.
      Object literal may only specify known properties, and 'showinfo' does not exist in type 'Options'.
    36 |           width: '100%',
    37 |           height: '100%',
  > 38 |           showinfo: 0,
       |           ^
    39 |         }}
    40 |       />
    41 |     </YoutubeDiv>```