### PR TITLE
Fix serializeNodes when props are undefined / null

### DIFF
--- a/packages/core/src/utils/serializeNode.tsx
+++ b/packages/core/src/utils/serializeNode.tsx
@@ -15,7 +15,7 @@ export const serializeComp = (
   resolver: Resolver
 ): ReducedComp => {
   let { type, isCanvas, props } = data;
-  props = Object.keys(props).reduce((result: Record<string, any>, key) => {
+  props = Object.keys(props || {}).reduce((result: Record<string, any>, key) => {
     const prop = props[key];
     if (!prop) {
       return result;


### PR DESCRIPTION
We're getting the error
```
index.js:362 TypeError: Cannot convert undefined or null to object
    at keys (<anonymous>)
    at Function.keys (es5-shim.js:1312)
    at serializeComp (index.js:1111)
    at index.js:1125
    at Array.reduce (<anonymous>)
    at serializeComp (index.js:1111)
    at serializeNode (index.js:1140)
    at Object.toSerializedNode (index.js:1288)
    at index.js:1387
    at Array.map (<anonymous>)
```
which appears to occur when props for an element (or a node within an element) is `null` or `undefined`, rather than `{}`.  I'm not sure exactly why this is happening at this point, but this seems to fix it.