### PR TITLE
Fix handlers insertion when using an iframe

### DIFF
--- a/packages/core/src/events/Events.tsx
+++ b/packages/core/src/events/Events.tsx
@@ -29,6 +29,7 @@ export const Events: React.FC = ({ children }) => {
               : indicator.success,
             transition: '0.2s ease-in',
           },
+          parentDom: events.indicator.placement.parent.dom,
         })}
       {children}
     </EventHandlerContext.Provider>

--- a/packages/utils/src/Handlers.ts
+++ b/packages/utils/src/Handlers.ts
@@ -76,7 +76,7 @@ class WatchHandler {
     this.unsubscribe = store.subscribe(
       (state) => ({ enabled: state.options.enabled }),
       ({ enabled }) => {
-        if (!document.body.contains(el)) {
+        if (!el.ownerDocument.body.contains(el)) {
           this.remove();
           return this.unsubscribe();
         }
@@ -171,7 +171,7 @@ export abstract class Handlers<T extends string = null> {
       }
 
       const connector = (el, opts) => {
-        if (!el || !document.body.contains(el)) {
+        if (!el || !el.ownerDocument.body.contains(el)) {
           this.wm.delete(el);
           return;
         }

--- a/packages/utils/src/RenderIndicator.tsx
+++ b/packages/utils/src/RenderIndicator.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 
-export const RenderIndicator: React.FC<any> = ({ style }) => {
-  return (
+export const RenderIndicator: React.FC<any> = ({ style, parentDom }) => {
+  const indicator = (
     <div
       style={{
         position: 'fixed',
@@ -15,4 +16,10 @@ export const RenderIndicator: React.FC<any> = ({ style }) => {
       }}
     ></div>
   );
+
+  if (parentDom && parentDom.ownerDocument !== document) {
+    return ReactDOM.createPortal(indicator, parentDom.ownerDocument.body);
+  }
+
+  return indicator;
 };


### PR DESCRIPTION
This simple change allows using craftjs with an iframe that contains all the building nodes. 
It's important for me because I want to build a page that doesn't have the same style as the editor, so using an iframe allows to reset all the styles and start from scratch.

Some work needs to be done for the "packages/core/src/events/Events.tsx" file, because the "RenderIndicator" component should be rendered inside the iframe, not in the parent document.
I'm looking for a way to make the change as simple as possibile.