### PR TITLE
feat: add grid to styleInFlow

### DIFF
--- a/packages/utils/src/getDOMInfo.ts
+++ b/packages/utils/src/getDOMInfo.ts
@@ -80,6 +80,7 @@ export const styleInFlow = (el: HTMLElement, parent: HTMLElement) => {
     case 'list-item':
     case 'table':
     case 'flex':
+    case 'grid':
       return true;
   }
   return;


### PR DESCRIPTION
Currently, `grid` user components have a different drag/drop interaction than `flex` – this PR adds `grid` to the list of display styles that enable `styleInFlow`.