### PR TITLE
Improve drag previews

### DIFF
--- a/packages/core/src/events/DefaultEventHandlers.ts
+++ b/packages/core/src/events/DefaultEventHandlers.ts
@@ -141,20 +141,43 @@ export class DefaultEventHandlers extends CoreEventHandlers {
         ],
       },
       create: {
-        init: (el) => {
+        init: (el, _, previewImageUrl) => {
           el.setAttribute('draggable', 'true');
+
+          if (previewImageUrl) {
+            // Preload preview image
+            const preImg = document.createElement('link');
+            preImg.href = previewImageUrl;
+            preImg.rel = 'preload';
+            preImg.as = 'image';
+            document.head.appendChild(preImg);
+          }
+
           return () => el.removeAttribute('draggable');
         },
         events: [
           defineEventListener(
             'dragstart',
-            (e: CraftDOMEvent<DragEvent>, userElement: React.ReactElement) => {
+            (
+              e: CraftDOMEvent<DragEvent>,
+              userElement: React.ReactElement,
+              previewImageUrl?: string
+            ) => {
               e.craft.stopPropagation();
               const tree = this.store.query
                 .parseReactElement(userElement)
                 .toNodeTree();
 
-              DefaultEventHandlers.draggedElementShadow = createShadow(e);
+              if (previewImageUrl) {
+                // Custom drag image
+
+                const previewImage = new Image();
+                previewImage.src = previewImageUrl;
+                e.dataTransfer.setDragImage(previewImage, 0, 0);
+              } else {
+                DefaultEventHandlers.draggedElementShadow = createShadow(e);
+              }
+
               DefaultEventHandlers.draggedElement = tree;
             }
           ),

--- a/packages/docs/docs/api/useEditor.md
+++ b/packages/docs/docs/api/useEditor.md
@@ -29,7 +29,7 @@ const { connectors, actions, query, ...collected } = useEditor(collector);
       ["select", "(dom: HTMLElement, nodeId: NodeId) => HTMLElement", "Specifies the DOM that when clicked will in turn click the specified Node's user component"],
       ["hover", "(dom: HTMLElement, nodeId: NodeId) => HTMLElement", "Specifies the DOM that when hovered will in turn hover the specified Node's user component"],
       ["drag", "(dom: HTMLElement, nodeId: NodeId) => HTMLElement", "Specifies the DOM that when dragged will move the specified Node's user component. Only applicable if the component is rendered as an immediate child of a &lt;Canvas /&gt; component."],
-      ["create", "(dom: HTMLElement, userElement: React.ReactElement) => HTMLElement", "Specifies the DOM that when dragged will create a new instance of the specified User Element at the drop location."]
+      ["create", "(dom: HTMLElement, userElement: React.ReactElement, previewImageUrl: string) => HTMLElement", "Specifies the DOM that when dragged will create a new instance of the specified User Element at the drop location."]
     ]],
     ["actions", "ActionMethods", [
       ["add", "(nodes: Node, parentId?: NodeId, index?: number) => void", "Add a Node to the given parent node ID at the specified index. By default the parentId is the id of the Root Node"],

--- a/packages/examples/basic/components/Toolbox.js
+++ b/packages/examples/basic/components/Toolbox.js
@@ -30,11 +30,15 @@ export const Toolbox = () => {
         <Grid container direction="column" item>
           <MaterialButton
             ref={(ref) =>
-              connectors.create(ref, <Button text="Click me" size="small" />)
+              connectors.create(
+                ref,
+                <Button text="Click me" size="small" />,
+                'http://placekitten.com/200/200'
+              )
             }
             variant="contained"
           >
-            Button
+            Button with drag image preview
           </MaterialButton>
         </Grid>
         <Grid container direction="column" item>

--- a/packages/examples/basic/components/Toolbox.js
+++ b/packages/examples/basic/components/Toolbox.js
@@ -72,7 +72,7 @@ export const Toolbox = () => {
               connectors.create(
                 ref,
                 <Button text="Click me" size="small" />,
-                'http://placekitten.com/200/200'
+                'https://placekitten.com/200/200'
               )
             }
             variant="contained"

--- a/packages/examples/basic/components/Toolbox.js
+++ b/packages/examples/basic/components/Toolbox.js
@@ -30,15 +30,11 @@ export const Toolbox = () => {
         <Grid container direction="column" item>
           <MaterialButton
             ref={(ref) =>
-              connectors.create(
-                ref,
-                <Button text="Click me" size="small" />,
-                'http://placekitten.com/200/200'
-              )
+              connectors.create(ref, <Button text="Click me" size="small" />)
             }
             variant="contained"
           >
-            Button with drag image preview
+            Button
           </MaterialButton>
         </Grid>
         <Grid container direction="column" item>
@@ -68,6 +64,20 @@ export const Toolbox = () => {
             variant="contained"
           >
             Card
+          </MaterialButton>
+        </Grid>
+        <Grid container direction="column" item>
+          <MaterialButton
+            ref={(ref) =>
+              connectors.create(
+                ref,
+                <Button text="Click me" size="small" />,
+                'http://placekitten.com/200/200'
+              )
+            }
+            variant="contained"
+          >
+            Customized drag preview
           </MaterialButton>
         </Grid>
       </Grid>

--- a/packages/utils/src/wrapConnectorHooks.tsx
+++ b/packages/utils/src/wrapConnectorHooks.tsx
@@ -53,13 +53,13 @@ function throwIfCompositeComponentElement(element: React.ReactElement<any>) {
 }
 
 export function wrapHookToRecognizeElement(
-  hook: (node: any, opts: any) => void
+  hook: (node: any, opts: any, previewImage?: string) => void
 ) {
-  return (elementOrNode = null, opts: any) => {
+  return (elementOrNode = null, opts: any, previewImage: string) => {
     // When passed a node, call the hook straight away.
     if (!isValidElement(elementOrNode)) {
       const node = elementOrNode;
-      node && hook(node, opts);
+      node && hook(node, opts, previewImage);
       return node;
     }
 
@@ -81,5 +81,6 @@ export type ConnectableElement =
 
 export type Connector = (
   elementOrNode: ConnectableElement,
-  options?: any
+  options?: any,
+  previewImage?: string
 ) => React.ReactElement | null;


### PR DESCRIPTION
Adds possibility to set a custom image for drag preview.

Syntax:
```
connectors.create(
  ref,
  <Button text="Click me" size="small" />,
  'http://placekitten.com/200/200'  <- optional preview image
)
```

Inspired by react-dnd.

* Basic example updated
* Docs updated