### PR TITLE
fix: slate op

### DIFF
--- a/packages/slate/src/utils/applyIdOnOperation.ts
+++ b/packages/slate/src/utils/applyIdOnOperation.ts
@@ -5,8 +5,6 @@ const fieldForOperation = {
   // eslint-disable-next-line @typescript-eslint/camelcase
   insert_node: 'node',
   // eslint-disable-next-line @typescript-eslint/camelcase
-  set_node: 'newProperties',
-  // eslint-disable-next-line @typescript-eslint/camelcase
   split_node: 'properties',
 };
 


### PR DESCRIPTION
Remove `set_node` op when generating new ids