### PR TITLE
fix: remove drag connector in slate

### DIFF
--- a/packages/slate/src/extend/editable/Element.tsx
+++ b/packages/slate/src/extend/editable/Element.tsx
@@ -11,15 +11,26 @@ const RenderSlateElement = ({
   attributes,
   children,
   renderElement,
+  drag,
 }) => {
   const { type } = useEditor((state) => ({
     type: state.options.resolver[element.type],
   }));
 
-  const render = React.createElement(type, { element, children, attributes });
+  const render = React.createElement(type, {
+    element,
+    children,
+    attributes,
+    drag,
+  });
 
   if (renderElement) {
-    return React.createElement(renderElement, { render, element });
+    return React.createElement(renderElement, {
+      render,
+      element,
+      attributes,
+      drag,
+    });
   }
 
   return render;
@@ -61,7 +72,6 @@ export const Element = ({ attributes, children, element, renderElement }) => {
     }
 
     connect(dom, id);
-    drag(dom, id);
 
     if (!enabled) {
       dom.setAttribute('contenteditable', false);
@@ -79,6 +89,13 @@ export const Element = ({ attributes, children, element, renderElement }) => {
           element={element}
           attributes={attributes}
           children={children}
+          drag={(dom) => {
+            if (!exists) {
+              return;
+            }
+
+            drag(dom, id);
+          }}
         />
       }
     />

--- a/packages/slate/src/extend/editable/RenderEditable.tsx
+++ b/packages/slate/src/extend/editable/RenderEditable.tsx
@@ -18,7 +18,6 @@ export const RenderEditable = ({ as, children, attributes }) => {
     }
 
     connectors.connect(dom, slateNodeId);
-    connectors.drag(dom, slateNodeId);
   });
 
   return React.createElement(as || DefaultRenderEditable, {


### PR DESCRIPTION
This PR remove the automatic attachment of drag connectors to all Slate Element node

- This is because Firefox/Safari do not work well with HTML elements that's both `draggable` and `contenteditable`. Hence, we expose a `drag` property to each Slate elements so the developer could handle the drag behaviour accordingly