### PR TITLE
hotfix: clear events prior to updating nodes state

### DIFF
--- a/packages/core/src/editor/actions.ts
+++ b/packages/core/src/editor/actions.ts
@@ -252,8 +252,8 @@ const Methods = (
     },
 
     replaceNodes(nodes: Nodes) {
-      state.nodes = nodes;
       this.clearEvents();
+      state.nodes = nodes;
     },
 
     clearEvents() {


### PR DESCRIPTION
- Fixes editor crash when deserializing