### PR TITLE
fix(slate): split operation bug

### DIFF
--- a/packages/slate/src/normalization/getSplitOperations.ts
+++ b/packages/slate/src/normalization/getSplitOperations.ts
@@ -18,6 +18,7 @@ export const getSplitOperations = (
     parentId: string,
     parentTree: any = {}
   ) => {
+    let hasCurrentNodeBeenExpelled = false;
     const operations = [];
     const node = state.nodes[nodeId];
 
@@ -46,6 +47,7 @@ export const getSplitOperations = (
 
       currentTree = null;
       hasSplitted = true;
+      hasCurrentNodeBeenExpelled = true;
     } else {
       if (!currentTree) {
         currentTree = { ...parentTree };
@@ -77,6 +79,11 @@ export const getSplitOperations = (
 
       currentTree[nodeId] = { ...nodeInfo };
       parentTree[nodeId] = { ...nodeInfo };
+    }
+
+    // If the current node has been expelled, no need to iterate through its children
+    if (hasCurrentNodeBeenExpelled) {
+      return operations;
     }
 
     return [

--- a/packages/slate/src/normalization/tests/getSplitOperations.test.ts
+++ b/packages/slate/src/normalization/tests/getSplitOperations.test.ts
@@ -115,9 +115,36 @@ describe('splitSlate', () => {
                 type: 'Typography',
                 nodes: [
                   {
-                    id: 'S2B1',
+                    id: 'S2C1',
                     data: {
-                      type: 'Button',
+                      type: 'Card',
+                      nodes: [
+                        {
+                          id: 'SLATE3',
+                          data: {
+                            type: 'SLATE',
+                            nodes: [
+                              {
+                                id: 'S3T1',
+                                data: {
+                                  type: 'Typography',
+                                  nodes: [
+                                    {
+                                      id: 'S3TT1',
+                                      data: {
+                                        type: 'Text',
+                                        props: {
+                                          text: 'Hello',
+                                        },
+                                      },
+                                    },
+                                  ],
+                                },
+                              },
+                            ],
+                          },
+                        },
+                      ],
                     },
                   },
                   {
@@ -238,7 +265,7 @@ describe('splitSlate', () => {
   it('should expel nested non-Slate node from nested Slate node', () => {
     expect(operations[5]).toEqual({
       type: 'expel',
-      id: 'S2B1',
+      id: 'S2C1',
     });
   });
   it('should have created a new Slate tree for the remaining Slate nodes', () => {

--- a/packages/slate/src/normalization/tests/splitSlate.test.ts
+++ b/packages/slate/src/normalization/tests/splitSlate.test.ts
@@ -149,6 +149,39 @@ describe('splitSlate', () => {
                 type: 'Typography',
                 nodes: [
                   {
+                    id: 'S2C1',
+                    data: {
+                      type: 'Card',
+                      nodes: [
+                        {
+                          id: 'SLATE3',
+                          data: {
+                            type: 'SLATE',
+                            nodes: [
+                              {
+                                id: 'S3T1',
+                                data: {
+                                  type: 'Typography',
+                                  nodes: [
+                                    {
+                                      id: 'S3TT1',
+                                      data: {
+                                        type: 'Text',
+                                        props: {
+                                          text: 'Hello',
+                                        },
+                                      },
+                                    },
+                                  ],
+                                },
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                  {
                     id: 'S2TT1',
                     data: {
                       type: 'Text',
@@ -206,9 +239,9 @@ describe('splitSlate', () => {
       expect(state.nodes[nestedChildListItemId].data.nodes).toEqual(['TT6']);
     });
     it('should have expanded nested Slate node', () => {
-      const newSlateNodeId = state.nodes['ROOT'].data.nodes[4];
+      expect(state.nodes['ROOT'].data.nodes[5]).toEqual('S2C1');
+      const newSlateNodeId = state.nodes['ROOT'].data.nodes[6];
       const lastNodeIndex = state.nodes[newSlateNodeId].data.nodes.length - 1;
-      expect(state.nodes[newSlateNodeId].data.nodes).not.toContain('SLATE2');
       expect(state.nodes[newSlateNodeId].data.nodes[lastNodeIndex]).toEqual(
         'S2T1'
       );


### PR DESCRIPTION
- Fix crash when a non-Slate node with a nested Slate child is dropped into another Slate parent