### PR TITLE
fix: css grid drag and drop jank

### DIFF
--- a/packages/utils/src/getDOMInfo.ts
+++ b/packages/utils/src/getDOMInfo.ts
@@ -55,6 +55,9 @@ export const styleInFlow = (el: HTMLElement, parent: HTMLElement) => {
 
   if (style.overflow && style.overflow !== 'visible') return;
   if (parentStyle.float !== 'none') return;
+  if (parent && parentStyle.display === 'grid') {
+    return;
+  }
   if (
     parent &&
     parentStyle.display === 'flex' &&


### PR DESCRIPTION
Follow up from https://github.com/prevwong/craft.js/pull/151.

This PR fixes the CSS grid drag/drop jank:

https://user-images.githubusercontent.com/12195101/106777448-ff15df00-6612-11eb-998c-6cf5a4eaa000.mp4

