### PR TITLE
Added events.draggedOver part 2

### DIFF
--- a/packages/core/src/editor/actions.ts
+++ b/packages/core/src/editor/actions.ts
@@ -278,6 +278,7 @@ const Methods = (
       this.setNodeEvent('selected', null);
       this.setNodeEvent('hovered', null);
       this.setNodeEvent('dragged', null);
+      this.setNodeEvent('draggedOver', null);
       this.setIndicator(null);
     },
 

--- a/packages/core/src/editor/store.tsx
+++ b/packages/core/src/editor/store.tsx
@@ -16,6 +16,7 @@ export const editorInitialState: EditorState = {
     dragged: new Set<NodeId>(),
     selected: new Set<NodeId>(),
     hovered: new Set<NodeId>(),
+    draggedOver: new Set<NodeId>(),
   },
   indicator: null,
   handlers: null,

--- a/packages/core/src/events/DefaultEventHandlers.ts
+++ b/packages/core/src/events/DefaultEventHandlers.ts
@@ -148,6 +148,9 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
               return;
             }
 
+            const ancestors = store.query.node(targetId).ancestors();
+            store.actions.setNodeEvent('draggedOver', [targetId, ...ancestors]);
+
             let node = (draggedElement as unknown) as Node;
 
             if ((draggedElement as NodeTree).rootNodeId) {
@@ -293,5 +296,6 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
 
     store.actions.setIndicator(null);
     store.actions.setNodeEvent('dragged', null);
+    store.actions.setNodeEvent('draggedOver', null);
   }
 }

--- a/packages/core/src/interfaces/nodes.ts
+++ b/packages/core/src/interfaces/nodes.ts
@@ -20,7 +20,7 @@ export type UserComponent<T = any> = React.ComponentType<T> & {
 };
 
 export type NodeId = string;
-export type NodeEventTypes = 'selected' | 'dragged' | 'hovered';
+export type NodeEventTypes = 'selected' | 'dragged' | 'hovered' | 'draggedOver';
 
 export type Node = {
   id: NodeId;

--- a/packages/examples/basic/components/user/Card.js
+++ b/packages/examples/basic/components/user/Card.js
@@ -1,4 +1,4 @@
-import { Element, useNode } from '@craftjs/core';
+import { Element, useNode, useEditor } from '@craftjs/core';
 import React from 'react';
 
 import { Button } from './Button';
@@ -57,8 +57,22 @@ CardBottom.craft = {
 };
 
 export const Card = ({ background, padding = 20 }) => {
+  const { id } = useNode();
+  const { isDraggedOver } = useEditor((state) => {
+    return {
+      // we consider the card as being dragged over if one of its ancestors (CardTop or CardBottom)
+      // is being dragged over. This only works because neither CardTop nor CardBottom accept other canvases (Card or Container)
+      // as their children.
+      isDraggedOver: state.events.draggedOver.has(id),
+    };
+  });
+
   return (
-    <Container background={background} padding={padding}>
+    <Container
+      background={background}
+      padding={padding}
+      outline={isDraggedOver ? '2px dashed blue' : undefined}
+    >
       <Element canvas id="text" is={CardTop}>
         <Text text="Only texts" fontSize={20} />
         <Text text="are allowed up here" fontSize={15} />

--- a/packages/examples/basic/components/user/Container.js
+++ b/packages/examples/basic/components/user/Container.js
@@ -1,17 +1,46 @@
-import { useNode } from '@craftjs/core';
+import { useNode, useEditor } from '@craftjs/core';
 import { Slider } from '@material-ui/core';
 import { Paper, FormControl, FormLabel } from '@material-ui/core';
 import ColorPicker from 'material-ui-color-picker';
 import React from 'react';
 
-export const Container = ({ background, padding, children }) => {
+export const Container = ({ background, padding, children, outline }) => {
   const {
     connectors: { connect, drag },
+    id: containerNodeId,
   } = useNode();
+
+  const { isDraggedOver } = useEditor((state, query) => {
+    // we have to look through all the ancestors of the element that the user currently drags over
+    const { draggedOver: draggedOverNodes } = state.events;
+    let isDraggedOver = false;
+
+    for (const nodeId of draggedOverNodes) {
+      // we are looking for the first canvas element
+      if (query.node(nodeId).isCanvas()) {
+        // if the id of first canvas element is the same as this Container's id we know that the user is dragging over this Container
+        if (nodeId === containerNodeId) {
+          isDraggedOver = true;
+        }
+        // Since we are only interested in the first ancestor, we break out of the loop
+        break;
+      }
+    }
+
+    return {
+      isDraggedOver,
+    };
+  });
+
   return (
     <Paper
       ref={(ref) => connect(drag(ref))}
-      style={{ margin: '5px 0', background, padding: `${padding}px` }}
+      style={{
+        margin: '5px 0',
+        background,
+        padding: `${padding}px`,
+        outline: outline || isDraggedOver ? '2px blue dashed' : undefined,
+      }}
     >
       {children}
     </Paper>


### PR DESCRIPTION
This PR adds `draggedOver` to the `events`. It's almost the same as #37 but targets the `next` branch and the new EventHandlers, which also gives us a cleaner API. (#37 will be obsolete).

Since the new EventHandlers introduced a `Set` as the store for the EventHandlers, we can now store not only the id of the node we are dragging over, but all of its ancestors, too.

I also updated the Basic example with two different examples on how to make use of the new API.

Closes #28, #37, #183

---

The only complaint we have with the new API is the name `draggedOver`. @prevwong suggested to re-use the `hovered` event. If an element is being hovered, and the `dragged` event stores at least one nodeId, we are dragging over an element. I prefer a more explicit API over an implicit one. As a counter argument Prev suggested to make use of the `EventHelpers`. 

I, too am not a fan of the name `draggedOver` but lack the creativity to come up with a better name, but I prefer the DX of having an explicit event for dragging over elements. My argument is, that the developer could discover the API with just using code completion and without having to have a look at the documentation of `hovered` or looking at a guide / example.

Maybe @matdru,  @mresposito or @timc1 can chime in and discus the API. Not only these guys, but everyone is welcome to leave a comment. 👍 