### PR TITLE
chore: replace staging basic example URL with relative URL

### DIFF
--- a/config.js
+++ b/config.js
@@ -6,8 +6,8 @@ module.exports = {
       BASIC_EXAMPLE: 'https://craft.js.org/examples/basic/',
     },
     staging: {
-      LANDING: 'https://craftjs.netlify.com/',
-      DOCUMENTATION: 'https://craftjs.netlify.com/r/docs/overview/',
+      LANDING: '/',
+      DOCUMENTATION: '/r/docs/overview/',
       BASIC_EXAMPLE: '/examples/basic/',
     },
     development: {

--- a/config.js
+++ b/config.js
@@ -8,7 +8,7 @@ module.exports = {
     staging: {
       LANDING: 'https://craftjs.netlify.com/',
       DOCUMENTATION: 'https://craftjs.netlify.com/r/docs/overview/',
-      BASIC_EXAMPLE: 'https://craftjs.netlify.com/examples/basic/',
+      BASIC_EXAMPLE: '/examples/basic/',
     },
     development: {
       LANDING: 'http://localhost:3001/',


### PR DESCRIPTION
Currently when netlify is hosting the PR preview the URL for the basic example will link to the production example. This should fix that by providing a relative link.

Would it be possible to configure Netlify in a way, that they not only post the URL of the landing example, but also the basic example in their comment? 