### PR TITLE
feat: Added a callback function to connectors.create to get access to the added node

### DIFF
--- a/packages/core/src/events/CoreEventHandlers.ts
+++ b/packages/core/src/events/CoreEventHandlers.ts
@@ -3,6 +3,10 @@ import { DerivedEventHandlers, EventHandlers } from '@craftjs/utils';
 import { EditorStore } from '../editor/store';
 import { NodeId, NodeTree } from '../interfaces/nodes';
 
+export interface CreateHandlerOptions {
+  onCreate: (nodeTree: NodeTree) => void;
+}
+
 export class CoreEventHandlers<O = {}> extends EventHandlers<
   { store: EditorStore } & O
 > {
@@ -16,7 +20,7 @@ export class CoreEventHandlers<O = {}> extends EventHandlers<
       create: (
         el: HTMLElement,
         UserElement: React.ReactElement,
-        callbackFunction?: (nodeTree: NodeTree) => void
+        options?: Partial<CreateHandlerOptions>
       ) => {},
     };
   }

--- a/packages/core/src/events/CoreEventHandlers.ts
+++ b/packages/core/src/events/CoreEventHandlers.ts
@@ -1,7 +1,7 @@
 import { DerivedEventHandlers, EventHandlers } from '@craftjs/utils';
 
 import { EditorStore } from '../editor/store';
-import { NodeId } from '../interfaces/nodes';
+import { NodeId, NodeTree } from '../interfaces/nodes';
 
 export class CoreEventHandlers<O = {}> extends EventHandlers<
   { store: EditorStore } & O
@@ -13,7 +13,11 @@ export class CoreEventHandlers<O = {}> extends EventHandlers<
       hover: (el: HTMLElement, id: NodeId) => {},
       drag: (el: HTMLElement, id: NodeId) => {},
       drop: (el: HTMLElement, id: NodeId) => {},
-      create: (el: HTMLElement, UserElement: React.ReactElement) => {},
+      create: (
+        el: HTMLElement,
+        UserElement: React.ReactElement,
+        callbackFunction?: (nodeTree: NodeTree) => void
+      ) => {},
     };
   }
 }

--- a/packages/core/src/events/DefaultEventHandlers.ts
+++ b/packages/core/src/events/DefaultEventHandlers.ts
@@ -1,6 +1,6 @@
 import { isFunction } from 'lodash';
 
-import { CoreEventHandlers } from './CoreEventHandlers';
+import { CoreEventHandlers, CreateHandlerOptions } from './CoreEventHandlers';
 import { createShadow } from './createShadow';
 
 import { Indicator, NodeId, NodeTree, Node } from '../interfaces';
@@ -226,7 +226,7 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
       create: (
         el: HTMLElement,
         userElement: React.ReactElement,
-        callbackFunction?: (nodeTree: NodeTree) => void
+        options?: Partial<CreateHandlerOptions>
       ) => {
         el.setAttribute('draggable', 'true');
 
@@ -259,8 +259,8 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
               index
             );
 
-            if (isFunction(callbackFunction)) {
-              callbackFunction(draggedElement);
+            if (options && isFunction(options.onCreate)) {
+              options.onCreate(draggedElement);
             }
           };
           this.dropElement(onDropElement);

--- a/packages/core/src/events/DefaultEventHandlers.ts
+++ b/packages/core/src/events/DefaultEventHandlers.ts
@@ -1,3 +1,5 @@
+import { isFunction } from 'lodash';
+
 import { CoreEventHandlers } from './CoreEventHandlers';
 import { createShadow } from './createShadow';
 
@@ -221,7 +223,11 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
           unbindDragEnd();
         };
       },
-      create: (el: HTMLElement, userElement: React.ReactElement) => {
+      create: (
+        el: HTMLElement,
+        userElement: React.ReactElement,
+        callbackFunction?: (nodeTree: NodeTree) => void
+      ) => {
         el.setAttribute('draggable', 'true');
 
         const unbindDragStart = this.addCraftEventListener(
@@ -252,6 +258,10 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
               placement.parent.id,
               index
             );
+
+            if (isFunction(callbackFunction)) {
+              callbackFunction(draggedElement);
+            }
           };
           this.dropElement(onDropElement);
         });

--- a/packages/utils/src/EventHandlers/ConnectorRegistry.ts
+++ b/packages/utils/src/EventHandlers/ConnectorRegistry.ts
@@ -5,13 +5,13 @@ import { Connector } from './interfaces';
 
 type ConnectorToRegister = {
   name: string;
-  opts: Record<string, any>;
-  additionalArguments: any[];
+  required: Record<string, any>;
+  options?: Record<string, any>;
   connector: Connector;
 };
 
 type RegisteredConnector = {
-  opts: Record<string, any>;
+  required: Record<string, any>;
   enable: () => void;
   disable: () => void;
 };
@@ -42,7 +42,12 @@ export class ConnectorRegistry {
 
   register(element: HTMLElement, toRegister: ConnectorToRegister) {
     if (this.get(element, toRegister.name)) {
-      if (isEqual(toRegister.opts, this.get(element, toRegister.name).opts)) {
+      if (
+        isEqual(
+          toRegister.required,
+          this.get(element, toRegister.name).required
+        )
+      ) {
         return;
       }
 
@@ -52,12 +57,12 @@ export class ConnectorRegistry {
     let cleanup: () => void | null = null;
 
     this.registry.set(this.getConnectorId(element, toRegister.name), {
-      opts: toRegister.opts,
+      required: toRegister.required,
       enable: () => {
         cleanup = toRegister.connector(
           element,
-          toRegister.opts,
-          ...toRegister.additionalArguments
+          toRegister.required,
+          toRegister.options
         );
       },
       disable: () => {

--- a/packages/utils/src/EventHandlers/ConnectorRegistry.ts
+++ b/packages/utils/src/EventHandlers/ConnectorRegistry.ts
@@ -5,13 +5,13 @@ import { Connector } from './interfaces';
 
 type ConnectorToRegister = {
   name: string;
-  required: Record<string, any>;
+  required: any;
   options?: Record<string, any>;
   connector: Connector;
 };
 
 type RegisteredConnector = {
-  required: Record<string, any>;
+  required: any;
   enable: () => void;
   disable: () => void;
 };

--- a/packages/utils/src/EventHandlers/ConnectorRegistry.ts
+++ b/packages/utils/src/EventHandlers/ConnectorRegistry.ts
@@ -6,6 +6,7 @@ import { Connector } from './interfaces';
 type ConnectorToRegister = {
   name: string;
   opts: Record<string, any>;
+  additionalArguments: any[];
   connector: Connector;
 };
 
@@ -53,7 +54,11 @@ export class ConnectorRegistry {
     this.registry.set(this.getConnectorId(element, toRegister.name), {
       opts: toRegister.opts,
       enable: () => {
-        cleanup = toRegister.connector(element, toRegister.opts);
+        cleanup = toRegister.connector(
+          element,
+          toRegister.opts,
+          ...toRegister.additionalArguments
+        );
       },
       disable: () => {
         if (!cleanup) {

--- a/packages/utils/src/EventHandlers/EventHandlers.ts
+++ b/packages/utils/src/EventHandlers/EventHandlers.ts
@@ -77,10 +77,11 @@ export abstract class EventHandlers<O extends Record<string, any> = {}> {
     return Object.keys(connectors).reduce(
       (accum, connectorName) => ({
         ...accum,
-        [connectorName]: (el, opts) => {
+        [connectorName]: (el, opts, ...args) => {
           this.registry.register(el, {
             opts,
             name: connectorName,
+            additionalArguments: args,
             connector: connectors[connectorName],
           });
           return el;

--- a/packages/utils/src/EventHandlers/EventHandlers.ts
+++ b/packages/utils/src/EventHandlers/EventHandlers.ts
@@ -77,11 +77,11 @@ export abstract class EventHandlers<O extends Record<string, any> = {}> {
     return Object.keys(connectors).reduce(
       (accum, connectorName) => ({
         ...accum,
-        [connectorName]: (el, opts, ...args) => {
+        [connectorName]: (el, required, options) => {
           this.registry.register(el, {
-            opts,
+            required,
             name: connectorName,
-            additionalArguments: args,
+            options,
             connector: connectors[connectorName],
           });
           return el;

--- a/packages/utils/src/EventHandlers/tests/EventHandlers.test.ts
+++ b/packages/utils/src/EventHandlers/tests/EventHandlers.test.ts
@@ -70,7 +70,8 @@ describe('EventHandlers', () => {
           expect(handlers.select.init).toHaveBeenNthCalledWith(
             1,
             dom,
-            'node-a'
+            'node-a',
+            undefined
           );
         });
       });


### PR DESCRIPTION
With this PR #180 should be possible without the `useEffect` workaround.

It is now possible to use the following code:

```jsx
<MaterialButton
  ref={(ref) => {
    connectors.create(
      ref,
      <Button text="Click me" size="small" />,
      // this will be called, when the node is dropped
      (nodeTree) => {
        // we can now select the node or do other stuff with it
        actions.selectNode(nodeTree.rootNodeId);
      }
    );
  }}
  variant="contained"
>
  Button
</MaterialButton>
```

---

To add this feature it was necessary to modify the `ConnectorRegistry`. I didn't want to change too much, that's why I added a `additionalArguments` attribute to the `ConnectorToRegistry` type and object. It would be possible to merge `opts` and `additionalArguments` and spread it instead of using [both](https://github.com/prevwong/craft.js/compare/next...ankri:connectors-create-callback?expand=1#diff-de010ce279171772b23f05f02efbdffcbe517cb55c59f41208355ccc8487ac1aR59-R60) .

I only added a callback function to `connectors.create` since I couldn't come up with a use case for the other connectors, but I think we could add such a callback to the others, too. 