### PR TITLE
Fix: Updating props from the outside

### DIFF
--- a/packages/core/src/nodes/Element.tsx
+++ b/packages/core/src/nodes/Element.tsx
@@ -1,5 +1,5 @@
 import { ERROR_TOP_LEVEL_ELEMENT_NO_ID, useEffectOnce } from '@craftjs/utils';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import invariant from 'tiny-invariant';
 
 import { NodeElement } from './NodeElement';
@@ -47,6 +47,16 @@ export function Element<T extends React.ElementType>({
   }));
 
   const [linkedNodeId, setLinkedNodeId] = useState<NodeId | null>(null);
+
+  useEffect(() => {
+    if (linkedNodeId) {
+      actions.history.ignore().setProp(linkedNodeId, (props) => {
+        Object.entries(otherProps).forEach(([key, value]) => {
+          props[key] = value;
+        });
+      });
+    }
+  }, [linkedNodeId, otherProps]);
 
   useEffectOnce(() => {
     invariant(!!id, ERROR_TOP_LEVEL_ELEMENT_NO_ID);

--- a/packages/examples/basic/pages/index.js
+++ b/packages/examples/basic/pages/index.js
@@ -1,4 +1,4 @@
-import { Editor, Frame, Element } from '@craftjs/core';
+import { Editor, Frame, Element, useNode } from '@craftjs/core';
 import { Typography, Paper, Grid, makeStyles } from '@material-ui/core';
 import React from 'react';
 
@@ -10,6 +10,62 @@ import { Card, CardBottom, CardTop } from '../components/user/Card';
 import { Container } from '../components/user/Container';
 import { Text } from '../components/user/Text';
 import '../styles/main.css';
+
+const Child = ({ count }) => {
+  const {
+    connectors: { connect, drag },
+  } = useNode();
+
+  console.log(count);
+
+  return (
+    <div
+      ref={(ref) => {
+        connect(drag(ref));
+      }}
+      style={{
+        padding: '1rem',
+        margin: '0.25rem',
+        border: '1px dashed blue',
+        flexGrow: 1,
+      }}
+    >
+      Count is {count}
+    </div>
+  );
+};
+
+const Parent = () => {
+  const {
+    connectors: { connect },
+  } = useNode();
+  const [count, setCount] = React.useState(0);
+
+  return (
+    <div
+      ref={connect}
+      style={{
+        padding: '1rem',
+        border: '1px dashed red',
+        marginBottom: '1rem',
+        display: 'flex',
+        flexDirection: 'row',
+      }}
+    >
+      <Element id="column" is={Child} count={count} />
+      <div>
+        <button
+          type="button"
+          onClick={() => {
+            setCount((count) => count + 1);
+          }}
+        >
+          Add One
+        </button>
+      </div>
+    </div>
+  );
+};
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -40,6 +96,7 @@ export default function App() {
           <Grid item xs>
             <Frame>
               <Element canvas is={Container} padding={5} background="#eeeeee">
+                <Parent />
                 <Card />
                 <Button text="Click me" size="small" />
                 <Text fontSize={20} text="Hi world!" />


### PR DESCRIPTION
My attempt at fixing the bug described in #190

You can test it in the [basic example](https://deploy-preview-191--craftjs.netlify.app/examples/basic/)

I found a solution but hit a dead end. With this fix the props of the components get updated. *BUT* the component now will be rendered twice. Once with the old props and immediately with the new props.

Maybe someone has an idea?