### PR TITLE
feat: additional indicator options

### DIFF
--- a/cypress/integration/history.ts
+++ b/cypress/integration/history.ts
@@ -51,7 +51,7 @@ describe('Test History', () => {
       .should('have.length', 1);
 
     // TODO currently I do not know why but without the wait. test gets flaky
-    //      and fails randomly because cypress is not able to drag the card into the container 
+    //      and fails randomly because cypress is not able to drag the card into the container
     cy.wait(100);
     cy.getByTestId('frame-card')
       .as('card')

--- a/packages/core/src/events/Events.tsx
+++ b/packages/core/src/events/Events.tsx
@@ -73,12 +73,13 @@ export const Events: React.FC = ({ children }) => {
               indicator.placement,
               getDOMInfo(indicator.placement.parent.dom),
               indicator.placement.currentNode &&
-                getDOMInfo(indicator.placement.currentNode.dom)
+                getDOMInfo(indicator.placement.currentNode.dom),
+              indicatorOptions.thickness
             ),
             backgroundColor: indicator.error
               ? indicatorOptions.error
               : indicatorOptions.success,
-            transition: '0.2s ease-in',
+            transition: indicatorOptions.transition || '0.2s ease-in',
           },
           parentDom: indicator.placement.parent.dom,
         })}

--- a/packages/core/src/events/movePlaceholder.ts
+++ b/packages/core/src/events/movePlaceholder.ts
@@ -3,7 +3,8 @@ import { DropAction, DOMInfo } from '../interfaces';
 export default function movePlaceholder(
   pos: DropAction,
   canvasDOMInfo: DOMInfo, // which canvas is cursor at
-  bestTargetDomInfo: DOMInfo | null // closest element in canvas (null if canvas is empty)
+  bestTargetDomInfo: DOMInfo | null, // closest element in canvas (null if canvas is empty)
+  thickness: number = 2
 ) {
   let t = 0,
     l = 0,
@@ -16,13 +17,13 @@ export default function movePlaceholder(
   if (elDim) {
     // If it's not in flow (like 'float' element)
     if (!elDim.inFlow) {
-      w = 2;
+      w = thickness;
       h = elDim.outerHeight;
       t = elDim.top;
       l = where === 'before' ? elDim.left : elDim.left + elDim.outerWidth;
     } else {
       w = elDim.outerWidth;
-      h = 2;
+      h = thickness;
       t = where === 'before' ? elDim.top : elDim.bottom;
       l = elDim.left;
     }
@@ -36,7 +37,7 @@ export default function movePlaceholder(
         canvasDOMInfo.padding.left -
         canvasDOMInfo.margin.left -
         canvasDOMInfo.margin.right;
-      h = 2;
+      h = thickness;
     }
   }
   return {

--- a/packages/core/src/interfaces/editor.ts
+++ b/packages/core/src/interfaces/editor.ts
@@ -13,7 +13,15 @@ export type Options = {
   onNodesChange: (query: QueryCallbacksFor<typeof QueryMethods>) => void;
   resolver: Resolver;
   enabled: boolean;
-  indicator: Record<'success' | 'error', string>;
+  indicator: Partial<{
+    success: string;
+    error: string;
+    transition: string;
+    /**
+     * height & width of the rendered indicator
+     */
+    thickness: number;
+  }>;
   handlers: (store: EditorStore) => CoreEventHandlers;
   normalizeNodes: (
     state: EditorState,


### PR DESCRIPTION
This PR enables us to add additional indicator options, specifically controlling:

- the ability to override the default `0.2ms` transition
- the thickness of the rendered indicator

https://user-images.githubusercontent.com/12195101/110573151-c04ed980-8128-11eb-8d60-0c06eac6473a.mp4

