### PR TITLE
hotfix: migrate immer

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,6 @@
     "@craftjs/utils": "^0.2.0-alpha.17",
     "@types/react": "^16.9.11",
     "debounce": "^1.2.0",
-    "immer": "^3.1.3",
     "lodash": "^4.17.20",
     "shortid": "^2.2.15",
     "tiny-invariant": "^1.0.6"

--- a/packages/core/src/editor/tests/actions.test.ts
+++ b/packages/core/src/editor/tests/actions.test.ts
@@ -1,5 +1,3 @@
-import { EditorState } from '@craftjs/core';
-import { produce } from 'immer';
 import mapValues from 'lodash/mapValues';
 
 import { QueryMethods } from '../../editor/query';
@@ -11,10 +9,12 @@ import {
 } from '../../utils/testHelpers';
 import { ActionMethods } from '../actions';
 
-const Actions = (state) => (cb) =>
-  produce<EditorState>(state, (draft) =>
-    cb(ActionMethods(draft as any, QueryMethods(state) as any))
-  );
+// TODO: create a cleaner way to test Action methods
+const Actions = (state) => (cb) => {
+  const methods = ActionMethods(state as any, QueryMethods(state) as any);
+  cb(methods);
+  return state;
+};
 
 describe('actions.add', () => {
   let state, rootNode;

--- a/packages/core/src/editor/tests/actions.test.ts
+++ b/packages/core/src/editor/tests/actions.test.ts
@@ -1,6 +1,7 @@
 import mapValues from 'lodash/mapValues';
 
 import { QueryMethods } from '../../editor/query';
+import { EditorState } from '../../interfaces';
 import { createNode } from '../../utils/createNode';
 import {
   createTestState,
@@ -10,8 +11,8 @@ import {
 import { ActionMethods } from '../actions';
 
 // TODO: create a cleaner way to test Action methods
-const Actions = (state) => (cb) => {
-  const methods = ActionMethods(state as any, QueryMethods(state) as any);
+const Actions = (state: EditorState) => (cb) => {
+  const methods = ActionMethods(state, QueryMethods(state) as any);
   cb(methods);
   return state;
 };

--- a/packages/core/src/interfaces/nodes.ts
+++ b/packages/core/src/interfaces/nodes.ts
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { QueryMethods } from '../editor/query';
 
-export type UserComponentConfig<T> = {
+type UserComponentConfig<T> = {
   displayName: string;
   rules: Partial<NodeRules>;
   related: Partial<NodeRelated>;

--- a/packages/core/src/interfaces/nodes.ts
+++ b/packages/core/src/interfaces/nodes.ts
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { QueryMethods } from '../editor/query';
 
-type UserComponentConfig<T> = {
+export type UserComponentConfig<T> = {
   displayName: string;
   rules: Partial<NodeRules>;
   related: Partial<NodeRelated>;

--- a/packages/core/src/utils/createNode.ts
+++ b/packages/core/src/utils/createNode.ts
@@ -12,8 +12,8 @@ import {
 } from '../nodes';
 import { NodeProvider } from '../nodes/NodeContext';
 
-const getNodeTypeName = (type: any) =>
-  typeof type == 'string' ? type : (type as any).name;
+const getNodeTypeName = (type: string | { name: string }) =>
+  typeof type == 'string' ? type : type.name;
 
 export function createNode(
   newNode: FreshNode,

--- a/packages/core/src/utils/createNode.ts
+++ b/packages/core/src/utils/createNode.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { getRandomNodeId } from './getRandomNodeId';
 
-import { Node, FreshNode, UserComponentConfig } from '../interfaces';
+import { Node, FreshNode } from '../interfaces';
 import {
   defaultElementProps,
   Element,
@@ -23,7 +23,6 @@ export function createNode(
   let id = newNode.id || getRandomNodeId();
 
   const node: Node = {
-    ...newNode,
     id,
     _hydrationTimestamp: Date.now(),
     data: {
@@ -89,7 +88,8 @@ export function createNode(
     normalize(node);
   }
 
-  const userComponentConfig: UserComponentConfig<any> = actualType.craft;
+  // TODO: use UserComponentConfig type
+  const userComponentConfig = actualType.craft as any;
 
   if (userComponentConfig) {
     node.data.displayName =

--- a/packages/core/src/utils/createNode.ts
+++ b/packages/core/src/utils/createNode.ts
@@ -30,7 +30,7 @@ export function createNode(
       name: getNodeTypeName(actualType),
       displayName: getNodeTypeName(actualType),
       props: {},
-      custom: newNode.data.custom || {},
+      custom: {},
       parent: null,
       isCanvas: false,
       hidden: false,
@@ -97,11 +97,22 @@ export function createNode(
       userComponentConfig.name ||
       node.data.displayName;
 
-    node.data.isCanvas =
+    node.data.props = {
+      ...(userComponentConfig.props || userComponentConfig.defaultProps || {}),
+      ...node.data.props,
+    };
+
+    node.data.custom = {
+      ...(userComponentConfig.custom || {}),
+      ...node.data.custom,
+    };
+
+    if (
       userComponentConfig.isCanvas !== undefined &&
       userComponentConfig.isCanvas !== null
-        ? userComponentConfig.isCanvas
-        : node.data.isCanvas;
+    ) {
+      node.data.isCanvas = userComponentConfig.isCanvas;
+    }
 
     if (userComponentConfig.rules) {
       Object.keys(userComponentConfig.rules).forEach((key) => {
@@ -110,19 +121,6 @@ export function createNode(
         }
       });
     }
-
-    node.data.props = {
-      ...(userComponentConfig.props ||
-        userComponentConfig.defaultProps ||
-        actualType.craft.defaultProps ||
-        {}),
-      ...node.data.props,
-    };
-
-    node.data.custom = {
-      ...(userComponentConfig.custom || {}),
-      ...node.data.custom,
-    };
 
     if (userComponentConfig.related) {
       const relatedNodeContext = {

--- a/packages/core/src/utils/tests/createNode.test.tsx
+++ b/packages/core/src/utils/tests/createNode.test.tsx
@@ -1,3 +1,4 @@
+import { Element } from '../../nodes';
 import { createNode } from '../createNode';
 import { createTestNode } from '../createTestNode';
 
@@ -8,7 +9,7 @@ const expectNode = (node, testData) => {
   const match = createTestNode(node.id, {
     ...testData,
     props: isUserComponent
-      ? { ...(type.craft.defaultProps || {}), ...testData.props }
+      ? { ...(type.craft.props || {}), ...testData.props }
       : testData.props || {},
     custom: isUserComponent ? type.craft.custom : {},
     name: typeof type === 'string' ? type : type.name,
@@ -38,9 +39,10 @@ describe('createNode', () => {
   const props = { href: 'href' };
 
   describe('Returns correct type and props', () => {
-    it('should transform a link correctly', () => {
+    it('should create a Node object correctly', () => {
       const data = {
         type: 'a',
+        parent: null,
         props,
       };
 
@@ -73,29 +75,61 @@ describe('createNode', () => {
         },
       });
     });
-
-    describe('when a User Component is passed', () => {
-      const Component = () => {};
-      Component.craft = {
-        custom: {
-          css: {
-            background: '#fff',
+    describe('When type=Element', () => {
+      it('should parse Element props as node config', () => {
+        const testNode = {
+          data: {
+            type: Element,
+            parent: 'ROOT',
+            props: {
+              is: 'a',
+              href: 'craft.js.org',
+              style: { color: '#fff' },
+            },
           },
-        },
-        rules: {
-          canMoveIn: () => false,
-        },
-        defaultProps: {
-          text: '#000',
-        },
-        related: {
-          settings: () => {},
-        },
-      };
+        };
+        const node = createNode(testNode);
+
+        const { is: type, ...props } = testNode.data.props;
+
+        expectNode(node, {
+          type,
+          props,
+          parent: 'ROOT',
+        });
+      });
+    });
+    describe('when a User Component is passed', () => {
+      let Component;
+
+      beforeEach(() => {
+        Component = () => {
+          return null;
+        };
+
+        Component.craft = {
+          custom: {
+            css: {
+              background: '#fff',
+            },
+          },
+          rules: {
+            canMoveIn: () => false,
+          },
+          props: {
+            text: '#000',
+          },
+          related: {
+            settings: () => {},
+          },
+        };
+      });
 
       it('should return node with correct type and user component config', () => {
         const data = {
           type: Component,
+          parent: null,
+          props: {},
         };
 
         const node = createNode({

--- a/packages/layers/src/events/LayerHandlers.ts
+++ b/packages/layers/src/events/LayerHandlers.ts
@@ -70,17 +70,19 @@ export class LayerHandlers extends DerivedCoreEventHandlers<{
                   currentCanvasHovered.data.nodes[
                     currentCanvasHovered.data.nodes.length - 1
                   ];
-                if (!currNode) return;
-                indicator.placement.currentNode = editorStore.query
-                  .node(currNode)
-                  .get();
-                indicator.placement.index =
-                  currentCanvasHovered.data.nodes.length;
-                indicator.placement.where = 'after';
-                indicator.placement.parent = currentCanvasHovered;
+
+                if (!currNode) {
+                  return;
+                }
 
                 LayerHandlers.events.indicator = {
                   ...indicator,
+                  placement: {
+                    currentNode: editorStore.query.node(currNode).get(),
+                    index: currentCanvasHovered.data.nodes.length,
+                    where: 'after',
+                    parent: currentCanvasHovered,
+                  },
                   onCanvas: true,
                 };
 

--- a/packages/utils/src/History.ts
+++ b/packages/utils/src/History.ts
@@ -1,4 +1,4 @@
-import { Patch, applyPatches, enablePatches } from 'immer';
+import { Patch, applyPatches } from 'immer';
 
 type Timeline = Array<{
   patches: Patch[];
@@ -15,9 +15,6 @@ export const HISTORY_ACTIONS = {
 };
 
 export class History {
-  constructor() {
-    enablePatches();
-  }
   timeline: Timeline = [];
   pointer = -1;
 

--- a/packages/utils/src/useMethods.ts
+++ b/packages/utils/src/useMethods.ts
@@ -1,10 +1,18 @@
 // https://github.com/pelotom/use-methods
-import produce, { Patch, produceWithPatches } from 'immer';
+import produce, {
+  Patch,
+  produceWithPatches,
+  enableMapSet,
+  enablePatches,
+} from 'immer';
 import isEqualWith from 'lodash/isEqualWith';
 import { useMemo, useEffect, useRef, useReducer, useCallback } from 'react';
 
 import { History, HISTORY_ACTIONS } from './History';
 import { Delete } from './utilityTypes';
+
+enableMapSet();
+enablePatches();
 
 export type SubscriberAndCallbacksFor<
   M extends MethodsOrOptions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10432,11 +10432,6 @@ immer@1.10.0:
   resolved "https://registry.npmjs.org/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
   integrity sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
 
-immer@^3.1.3:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-3.3.0.tgz#ee7cf3a248d5dd2d4eedfbe7dfc1e9be8c72041d"
-  integrity sha512-vlWRjnZqoTHuEjadquVHK3GxsXe1gNoATffLEA8Qbrdd++Xb+wHEFiWtwAKTscMBoi1AsvEMXhYRzAXA8Ex9FQ==
-
 immer@^5.0.0:
   version "5.3.6"
   resolved "https://registry.yarnpkg.com/immer/-/immer-5.3.6.tgz#51eab8cbbeb13075fe2244250f221598818cac04"


### PR DESCRIPTION
This PR fixes the regressions caused by updating immer in #211 

- Manually enable `immer` plugins
  - `MapSet` => used by `state.events`  
  -  `Patches` => used by History
- Accommodate immer auto-freeze 
  - Fix unsafe object mutation in `LayerHandlers` 
  - Remove the usage of `produce` in `createNode`
    - Doing this also allows us to remove `immer` as a dependency from core   