### PR TITLE
Fix drag events not moving indicator when staying in the same node

### DIFF
--- a/packages/core/src/nodes/NodeElement.tsx
+++ b/packages/core/src/nodes/NodeElement.tsx
@@ -9,10 +9,12 @@ export type NodeElement = {
   id: NodeId;
 };
 
-export const NodeElement: React.FC<NodeElement> = React.memo(({ id }) => {
-  return (
-    <NodeProvider id={id}>
-      <RenderNodeToElement />
-    </NodeProvider>
-  );
-});
+export const NodeElement: React.FC<NodeElement> = React.memo(
+  ({ id, ...otherProps }) => {
+    return (
+      <NodeProvider id={id}>
+        <RenderNodeToElement {...otherProps} />
+      </NodeProvider>
+    );
+  }
+);

--- a/packages/core/src/render/RenderNode.tsx
+++ b/packages/core/src/render/RenderNode.tsx
@@ -7,8 +7,8 @@ import { NodeId } from '../interfaces';
 import { NodeElement } from '../nodes/NodeElement';
 import { useInternalNode } from '../nodes/useInternalNode';
 
-const Render = () => {
-  const { type, props, nodes, hydrationTimestamp } = useInternalNode(
+const Render = (otherProps: any) => {
+  const { type, props: nodeProps, nodes, hydrationTimestamp } = useInternalNode(
     (node) => ({
       type: node.data.type,
       props: node.data.props,
@@ -16,6 +16,11 @@ const Render = () => {
       hydrationTimestamp: node._hydrationTimestamp,
     })
   );
+
+  const props = {
+    ...nodeProps,
+    ...otherProps,
+  };
 
   return useMemo(() => {
     let children = props.children;
@@ -41,7 +46,7 @@ const Render = () => {
   }, [type, props, hydrationTimestamp, nodes]);
 };
 
-export const RenderNodeToElement: React.FC<any> = () => {
+export const RenderNodeToElement: React.FC<any> = (props) => {
   const { hidden } = useInternalNode((node) => ({
     hidden: node.data.hidden,
   }));
@@ -55,5 +60,5 @@ export const RenderNodeToElement: React.FC<any> = () => {
     return null;
   }
 
-  return React.createElement(onRender, { render: <Render /> });
+  return React.createElement(onRender, { render: <Render {...props} /> });
 };


### PR DESCRIPTION
This pull request fixes a problem when dragging nodes.
Drag events are not moving indicator when the mouse is staying in the same node.
This gifs explain it better:

If the mouse moves on different nodes, it works as expected:
![craftjs_bug_1](https://user-images.githubusercontent.com/118949/111786336-fa08a880-88bd-11eb-99fc-ac15c5ed3204.gif)


If you move the mouse **staying** in the same node, it doesn't work:
![craftjs_bug_2](https://user-images.githubusercontent.com/118949/111786327-f70db800-88bd-11eb-8bc2-c4dc0e4b315d.gif)

