### PR TITLE
chore(layers): mark styled-components as external dependencies

### DIFF
--- a/packages/layers/README.md
+++ b/packages/layers/README.md
@@ -27,7 +27,7 @@
 ## Usage
 
 ```bash
-yarn add @craftjs/layers
+yarn add @craftjs/layers styled-components
 ```
 
 ```jsx

--- a/packages/layers/package.json
+++ b/packages/layers/package.json
@@ -31,15 +31,16 @@
   },
   "homepage": "https://github.com/prevwong/craft.js/",
   "dependencies": {
-    "@craftjs/utils": "^0.1.0-beta.19",
-    "styled-components": "^4.2.1"
+    "@craftjs/utils": "^0.1.0-beta.19"
   },
   "devDependencies": {
     "@babel/core": "^7.7.4",
-    "@svgr/rollup": "^4.3.3"
+    "@svgr/rollup": "^4.3.3",
+    "styled-components": "^4.2.1"
   },
   "peerDependencies": {
     "@craftjs/core": "^0.1.0-alpha.1",
-    "react": "^16.8.0"
+    "react": "^16.8.0",
+    "styled-components": ">= 4"
   }
 }


### PR DESCRIPTION
Basically I get this warning because of the fact there are two conflicting styled-components in the application

```
It looks like there are several instances of 'styled-components' initialized in this application. This may cause dynamic styles not rendering properly, errors happening during rehydration process and makes your application bigger without a good reason.
```

The changes made are as suggested on the styled-components docs
https://styled-components.com/docs/faqs#i-am-a-library-author-should-i-bundle-styledcomponents-with-my-library