### PR TITLE
Replaced lodash with lodash-es in web bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,9 @@
       "tsx",
       "js"
     ],
+    "moduleNameMapper": {
+      "^lodash-es$": "lodash"
+    },
     "modulePaths": [
       "<rootDir>/packages/core/"
     ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,11 +38,12 @@
     "@craftjs/utils": "^0.1.0-beta.19",
     "@types/react": "^17.0.5",
     "debounce": "^1.2.0",
-    "lodash": "^4.17.20",
+    "lodash-es": "^4.17.20",
     "shortid": "^2.2.15",
     "tiny-invariant": "^1.0.6"
   },
   "devDependencies": {
+    "lodash": "^4.17.20",
     "react": "^17.0.2"
   },
   "peerDependencies": {

--- a/packages/core/src/editor/tests/actions.test.ts
+++ b/packages/core/src/editor/tests/actions.test.ts
@@ -1,4 +1,4 @@
-import mapValues from 'lodash/mapValues';
+import { mapValues } from 'lodash';
 
 import { QueryMethods } from '../../editor/query';
 import { EditorState } from '../../interfaces';

--- a/packages/core/src/events/DefaultEventHandlers.ts
+++ b/packages/core/src/events/DefaultEventHandlers.ts
@@ -1,4 +1,4 @@
-import { isFunction } from 'lodash';
+import { isFunction } from 'lodash-es';
 
 import { CoreEventHandlers, CreateHandlerOptions } from './CoreEventHandlers';
 import { createShadow } from './createShadow';

--- a/packages/core/src/render/tests/RenderNode.test.tsx
+++ b/packages/core/src/render/tests/RenderNode.test.tsx
@@ -1,5 +1,5 @@
 import { mount } from 'enzyme';
-import identity from 'lodash/identity';
+import { identity } from 'lodash';
 import React from 'react';
 
 import { NodeElement } from '../../nodes/NodeElement';

--- a/packages/core/src/utils/testHelpers.ts
+++ b/packages/core/src/utils/testHelpers.ts
@@ -1,4 +1,4 @@
-import cloneDeep from 'lodash/cloneDeep';
+import { cloneDeep } from 'lodash-es';
 
 import { createNode } from './createNode';
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@types/react": "^17.0.5",
     "immer": "^8.0.1",
-    "lodash": "^4.17.20",
+    "lodash-es": "^4.17.20",
     "shallowequal": "^1.1.0",
     "tiny-invariant": "^1.0.6"
   },
@@ -26,5 +26,8 @@
   ],
   "peerDependencies": {
     "react": "^16.8.0"
+  },
+  "devDependencies": {
+    "lodash": "^4.17.20"
   }
 }

--- a/packages/utils/src/useMethods.ts
+++ b/packages/utils/src/useMethods.ts
@@ -5,7 +5,7 @@ import produce, {
   enableMapSet,
   enablePatches,
 } from 'immer';
-import isEqualWith from 'lodash/isEqualWith';
+import { isEqualWith } from 'lodash-es';
 import { useMemo, useEffect, useRef, useReducer, useCallback } from 'react';
 
 import { History, HISTORY_ACTIONS } from './History';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3007,14 +3007,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@craftjs/core@^0.1.0-beta.18, @craftjs/core@workspace:packages/core":
+"@craftjs/core@^0.1.0-beta.19, @craftjs/core@workspace:packages/core":
   version: 0.0.0-use.local
   resolution: "@craftjs/core@workspace:packages/core"
   dependencies:
-    "@craftjs/utils": ^0.1.0-beta.18
+    "@craftjs/utils": ^0.1.0-beta.19
     "@types/react": ^17.0.5
     debounce: ^1.2.0
     lodash: ^4.17.20
+    lodash-es: ^4.17.20
     react: ^17.0.2
     shortid: ^2.2.15
     tiny-invariant: ^1.0.6
@@ -3023,27 +3024,28 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@craftjs/layers@^0.1.0-beta.18, @craftjs/layers@workspace:packages/layers":
+"@craftjs/layers@^0.1.0-beta.19, @craftjs/layers@workspace:packages/layers":
   version: 0.0.0-use.local
   resolution: "@craftjs/layers@workspace:packages/layers"
   dependencies:
     "@babel/core": ^7.7.4
-    "@craftjs/utils": ^0.1.0-beta.18
+    "@craftjs/utils": ^0.1.0-beta.19
     "@svgr/rollup": ^4.3.3
     styled-components: ^4.2.1
   peerDependencies:
-    "@craftjs/core": ^0.2.0-alpha.19
+    "@craftjs/core": ^0.1.0-alpha.1
     react: ^16.8.0
   languageName: unknown
   linkType: soft
 
-"@craftjs/utils@^0.1.0-beta.18, @craftjs/utils@workspace:packages/utils":
+"@craftjs/utils@^0.1.0-beta.19, @craftjs/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@craftjs/utils@workspace:packages/utils"
   dependencies:
     "@types/react": ^17.0.5
     immer: ^8.0.1
     lodash: ^4.17.20
+    lodash-es: ^4.17.20
     shallowequal: ^1.1.0
     tiny-invariant: ^1.0.6
   peerDependencies:
@@ -11692,7 +11694,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "example-basic@workspace:examples/basic"
   dependencies:
-    "@craftjs/core": ^0.1.0-beta.18
+    "@craftjs/core": ^0.1.0-beta.19
     "@material-ui/core": latest
     clsx: latest
     copy-to-clipboard: ^3.2.0
@@ -11712,8 +11714,8 @@ __metadata:
   resolution: "example-landing@workspace:examples/landing"
   dependencies:
     "@babel/core": ^7.7.5
-    "@craftjs/core": ^0.1.0-beta.18
-    "@craftjs/layers": ^0.1.0-beta.18
+    "@craftjs/core": ^0.1.0-beta.19
+    "@craftjs/layers": ^0.1.0-beta.19
     "@fullhuman/postcss-purgecss": ^1.3.0
     "@material-ui/core": ^4.5.2
     "@material-ui/icons": ^4.5.1
@@ -16341,6 +16343,13 @@ fsevents@~2.3.1:
   dependencies:
     p-locate: ^5.0.0
   checksum: 4c379638152e0e5fda9a8cc07005702f81fcb9899db0f66d691ac1e64193dea670af14e96c50f14d82d45959daa4c400cb712c158cffe22ae265bfc1b1e3a221
+  languageName: node
+  linkType: hard
+
+"lodash-es@npm:^4.17.20":
+  version: 4.17.21
+  resolution: "lodash-es@npm:4.17.21"
+  checksum: ff0e7bb9595594d8b9c32fbe15912eaeefd83266f6e6872fbc498533cf8c2f039d12d37034b33965f1c04ef66ec1d6da83377c77e84e14c51a137901bb50865e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
While doing bundle analysis for our project I noticed that the use of lodash in `@craftjs/core` results in the entire `lodash` bundle included in the web bundle (results below). This likely became part of the bundle with the export of `testHelpers` in [this commit](https://github.com/prevwong/craft.js/commit/c47cacd9b40ebecd88133ff0f72407be0104a353). 

The `lodash` bundle is not tree shakeable, and in my experience even using a single lodash function results in the entire bundle getting included. The [recommended solution](https://developers.google.com/web/fundamentals/performance/optimizing-javascript/tree-shaking/#when_things_arent_so_straightforward) is to use `lodash-es` instead.


**Before** - using `lodash` imports
![image](https://user-images.githubusercontent.com/3598113/121695348-98a53f80-ca90-11eb-9eb2-3098dd18b1d9.png)

**After** - using `lodash-es` imports
![image](https://user-images.githubusercontent.com/3598113/121695513-bc688580-ca90-11eb-8acc-55460039f51e.png)



- Updated all imports to use lodash-es instead of lodash
- Use jest file replacement for tests
- Added lodash dev dependency to support tests