### PR TITLE
chore: replace package shortid with nanoid

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,7 @@
     "@types/react": "^17.0.5",
     "debounce": "^1.2.0",
     "lodash": "^4.17.20",
-    "shortid": "^2.2.15",
+    "nanoid": "^3.1.23",
     "tiny-invariant": "^1.0.6"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,7 +39,6 @@
     "@types/react": "^17.0.5",
     "debounce": "^1.2.0",
     "lodash": "^4.17.20",
-    "nanoid": "^3.1.23",
     "tiny-invariant": "^1.0.6"
   },
   "devDependencies": {

--- a/packages/core/src/utils/createNode.ts
+++ b/packages/core/src/utils/createNode.ts
@@ -1,6 +1,5 @@
+import { getRandomId as getRandomNodeId } from '@craftjs/utils';
 import React from 'react';
-
-import { getRandomNodeId } from './getRandomNodeId';
 
 import { Node, FreshNode, UserComponentConfig } from '../interfaces';
 import {

--- a/packages/core/src/utils/getRandomNodeId.ts
+++ b/packages/core/src/utils/getRandomNodeId.ts
@@ -1,3 +1,0 @@
-import { nanoid } from 'nanoid';
-
-export const getRandomNodeId = nanoid;

--- a/packages/core/src/utils/getRandomNodeId.ts
+++ b/packages/core/src/utils/getRandomNodeId.ts
@@ -1,3 +1,3 @@
-import shortid from 'shortid';
+import { nanoid } from 'nanoid';
 
-export const getRandomNodeId = shortid;
+export const getRandomNodeId = nanoid;

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,6 +17,7 @@
     "@types/react": "^17.0.5",
     "immer": "^8.0.1",
     "lodash": "^4.17.20",
+    "nanoid": "^3.1.23",
     "shallowequal": "^1.1.0",
     "tiny-invariant": "^1.0.6"
   },

--- a/packages/utils/src/EventHandlers/ConnectorRegistry.ts
+++ b/packages/utils/src/EventHandlers/ConnectorRegistry.ts
@@ -1,7 +1,8 @@
-import { nanoid } from 'nanoid';
 import isEqual from 'shallowequal';
 
 import { Connector } from './interfaces';
+
+import { getRandomId } from '../getRandomId';
 
 type ConnectorToRegister = {
   name: string;
@@ -30,7 +31,7 @@ export class ConnectorRegistry {
       return existingId;
     }
 
-    const newId = nanoid();
+    const newId = getRandomId();
     this.elementIdMap.set(element, newId);
     return newId;
   }

--- a/packages/utils/src/EventHandlers/ConnectorRegistry.ts
+++ b/packages/utils/src/EventHandlers/ConnectorRegistry.ts
@@ -1,5 +1,5 @@
+import { nanoid } from 'nanoid';
 import isEqual from 'shallowequal';
-import shortid from 'shortid';
 
 import { Connector } from './interfaces';
 
@@ -30,7 +30,7 @@ export class ConnectorRegistry {
       return existingId;
     }
 
-    const newId = shortid();
+    const newId = nanoid();
     this.elementIdMap.set(element, newId);
     return newId;
   }

--- a/packages/utils/src/getRandomId.ts
+++ b/packages/utils/src/getRandomId.ts
@@ -1,0 +1,12 @@
+import { nanoid } from 'nanoid';
+
+// By default nanoid generate an ID with 21 characters. To reduce the footprint, we default to 10 characters.
+// We have a higher probability for collisions, though
+
+/**
+ * Generate a random ID. That ID can for example be used as a node ID.
+ *
+ * @param size The number of characters that are generated for the ID. Defaults to `10`
+ * @returns A random id
+ */
+export const getRandomId = (size: number = 10) => nanoid(size);

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -8,3 +8,4 @@ export * from './useEffectOnce';
 export * from './deprecate';
 export * from './utilityTypes';
 export * from './History';
+export * from './getRandomId';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3015,8 +3015,8 @@ __metadata:
     "@types/react": ^17.0.5
     debounce: ^1.2.0
     lodash: ^4.17.20
+    nanoid: ^3.1.23
     react: ^17.0.2
-    shortid: ^2.2.15
     tiny-invariant: ^1.0.6
   peerDependencies:
     react: ^16.8.0
@@ -17605,13 +17605,6 @@ fsevents@~2.3.1:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^2.1.0":
-  version: 2.1.6
-  resolution: "nanoid@npm:2.1.6"
-  checksum: b34d842ce85feeacd12275dc79728802e8b08f1466b66d00cf46f0883fcf9e40caceb504ea9f67c6921c0246a063f62c29ccd76a32bc7472cc699480a4831358
-  languageName: node
-  linkType: hard
-
 "nanoid@npm:^3.1.22, nanoid@npm:^3.1.23":
   version: 3.1.23
   resolution: "nanoid@npm:3.1.23"
@@ -23416,15 +23409,6 @@ resolve@^1.17.0:
   version: 0.1.1
   resolution: "shellwords@npm:0.1.1"
   checksum: 3559ff550917ece921d252edf42eb54827540e9676e537137ace236df8f9b78e48c542ae0b3f8876fea0faf5826c97629d5b8cb9ac7dee287260e9804fb8132c
-  languageName: node
-  linkType: hard
-
-"shortid@npm:^2.2.15":
-  version: 2.2.15
-  resolution: "shortid@npm:2.2.15"
-  dependencies:
-    nanoid: ^2.1.0
-  checksum: 0b657c406153029ba5fe3df357115d31c53929b6e603cbd2ff2aae7ddc016290179dfaa49625a3abc8967df8d53d04bd2c07a617562c1057ace8558f67558235
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3015,7 +3015,6 @@ __metadata:
     "@types/react": ^17.0.5
     debounce: ^1.2.0
     lodash: ^4.17.20
-    nanoid: ^3.1.23
     react: ^17.0.2
     tiny-invariant: ^1.0.6
   peerDependencies:
@@ -3044,6 +3043,7 @@ __metadata:
     "@types/react": ^17.0.5
     immer: ^8.0.1
     lodash: ^4.17.20
+    nanoid: ^3.1.23
     shallowequal: ^1.1.0
     tiny-invariant: ^1.0.6
   peerDependencies:


### PR DESCRIPTION
Issue #268 made me look into [shortid](https://www.npmjs.com/package/shortid) and I stumbled upon the deprecation message and the safety warning.

This PR replaces `shortid` with the suggested [`nanoid`](https://www.npmjs.com/package/nanoid). For existing projects old NodeIDs should still work but new ones would be generated with `nanoid`.

Only "disadvantage" if you can call it that, is that ids generated by `nanoid` are longer than `shortid`'s ids.  