### PR TITLE
Fix: Nested "type" key in Element props leads to serialization error

### DIFF
--- a/packages/core/src/utils/serializeNode.tsx
+++ b/packages/core/src/utils/serializeNode.tsx
@@ -20,7 +20,7 @@ export const serializeComp = (
   props = Object.keys(props).reduce((result: Record<string, any>, key) => {
     const prop = props[key];
 
-    if (prop === undefined || prop === null) {
+    if (prop === undefined || prop === null || typeof prop === 'function') {
       return result;
     }
 

--- a/packages/core/src/utils/serializeNode.tsx
+++ b/packages/core/src/utils/serializeNode.tsx
@@ -31,7 +31,7 @@ export const serializeComp = (
         }
         return serializeComp(child, resolver);
       });
-    } else if (prop.type) {
+    } else if (typeof prop.type === 'function') {
       result[key] = serializeComp(prop, resolver);
     } else {
       result[key] = prop;


### PR DESCRIPTION
This fix addresses the issue when `type` is nested as a key on the data that is used, resolving the following issues/PRs:
https://github.com/prevwong/craft.js/issues/225 and https://github.com/prevwong/craft.js/pull/251