### PR TITLE
feat: support custom nodeTree in connectors.create()

### DIFF
--- a/packages/core/src/events/CoreEventHandlers.ts
+++ b/packages/core/src/events/CoreEventHandlers.ts
@@ -19,7 +19,7 @@ export class CoreEventHandlers<O = {}> extends EventHandlers<
       drop: (el: HTMLElement, id: NodeId) => {},
       create: (
         el: HTMLElement,
-        UserElement: React.ReactElement,
+        UserElement: React.ReactElement | (() => NodeTree | React.ReactElement),
         options?: Partial<CreateHandlerOptions>
       ) => {},
     };

--- a/packages/core/src/events/DefaultEventHandlers.ts
+++ b/packages/core/src/events/DefaultEventHandlers.ts
@@ -258,7 +258,7 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
             e.craft.stopPropagation();
             let tree;
             if (typeof userElement === 'function') {
-              let result = userElement();
+              const result = userElement();
               if (React.isValidElement(result)) {
                 tree = store.query.parseReactElement(result).toNodeTree();
               } else {

--- a/packages/core/src/events/DefaultEventHandlers.ts
+++ b/packages/core/src/events/DefaultEventHandlers.ts
@@ -258,12 +258,11 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
             e.craft.stopPropagation();
             let tree;
             if (typeof userElement === 'function') {
-              if (React.isValidElement(userElement())) {
-                tree = store.query
-                  .parseReactElement(userElement() as React.ReactElement)
-                  .toNodeTree();
+              let result = userElement();
+              if (React.isValidElement(result)) {
+                tree = store.query.parseReactElement(result).toNodeTree();
               } else {
-                tree = userElement();
+                tree = result;
               }
             } else {
               tree = store.query.parseReactElement(userElement).toNodeTree();

--- a/packages/core/src/events/DefaultEventHandlers.ts
+++ b/packages/core/src/events/DefaultEventHandlers.ts
@@ -1,6 +1,5 @@
 import { isChromium, isLinux } from '@craftjs/utils';
 import { isFunction } from 'lodash';
-import { isValidElement } from 'react';
 
 import { CoreEventHandlers, CreateHandlerOptions } from './CoreEventHandlers';
 import { Positioner } from './Positioner';
@@ -256,9 +255,10 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
           'dragstart',
           (e) => {
             e.craft.stopPropagation();
-            const tree = isValidElement(userElement)
-              ? store.query.parseReactElement(userElement).toNodeTree()
-              : userElement();
+            const tree =
+              typeof userElement === 'function'
+                ? userElement()
+                : store.query.parseReactElement(userElement).toNodeTree();
 
             const dom = e.currentTarget as HTMLElement;
             this.draggedElementShadow = createShadow(

--- a/packages/core/src/events/DefaultEventHandlers.ts
+++ b/packages/core/src/events/DefaultEventHandlers.ts
@@ -1,5 +1,6 @@
 import { isChromium, isLinux } from '@craftjs/utils';
 import { isFunction } from 'lodash';
+import React from 'react';
 
 import { CoreEventHandlers, CreateHandlerOptions } from './CoreEventHandlers';
 import { Positioner } from './Positioner';
@@ -245,7 +246,7 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
       },
       create: (
         el: HTMLElement,
-        userElement: React.ReactElement | (() => NodeTree),
+        userElement: React.ReactElement | (() => NodeTree | React.ReactElement),
         options?: Partial<CreateHandlerOptions>
       ) => {
         el.setAttribute('draggable', 'true');

--- a/packages/core/src/events/DefaultEventHandlers.ts
+++ b/packages/core/src/events/DefaultEventHandlers.ts
@@ -1,6 +1,6 @@
 import { isChromium, isLinux } from '@craftjs/utils';
 import { isFunction } from 'lodash';
-import React from 'react';
+import React, { isValidElement } from 'react';
 
 import { CoreEventHandlers, CreateHandlerOptions } from './CoreEventHandlers';
 import { Positioner } from './Positioner';
@@ -256,10 +256,18 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
           'dragstart',
           (e) => {
             e.craft.stopPropagation();
-            const tree =
-              typeof userElement === 'function'
-                ? userElement()
-                : store.query.parseReactElement(userElement).toNodeTree();
+            let tree;
+            if (typeof userElement === 'function') {
+              if (isValidElement(userElement())) {
+                tree = store.query
+                  .parseReactElement(userElement() as React.ReactElement)
+                  .toNodeTree();
+              } else {
+                tree = userElement();
+              }
+            } else {
+              tree = store.query.parseReactElement(userElement).toNodeTree();
+            }
 
             const dom = e.currentTarget as HTMLElement;
             this.draggedElementShadow = createShadow(

--- a/packages/core/src/events/DefaultEventHandlers.ts
+++ b/packages/core/src/events/DefaultEventHandlers.ts
@@ -1,6 +1,6 @@
 import { isChromium, isLinux } from '@craftjs/utils';
 import { isFunction } from 'lodash';
-import React, { isValidElement } from 'react';
+import React from 'react';
 
 import { CoreEventHandlers, CreateHandlerOptions } from './CoreEventHandlers';
 import { Positioner } from './Positioner';
@@ -258,7 +258,7 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
             e.craft.stopPropagation();
             let tree;
             if (typeof userElement === 'function') {
-              if (isValidElement(userElement())) {
+              if (React.isValidElement(userElement())) {
                 tree = store.query
                   .parseReactElement(userElement() as React.ReactElement)
                   .toNodeTree();

--- a/packages/core/src/events/DefaultEventHandlers.ts
+++ b/packages/core/src/events/DefaultEventHandlers.ts
@@ -1,11 +1,12 @@
 import { isChromium, isLinux } from '@craftjs/utils';
 import { isFunction } from 'lodash';
+import { isValidElement } from 'react';
 
 import { CoreEventHandlers, CreateHandlerOptions } from './CoreEventHandlers';
 import { Positioner } from './Positioner';
 import { createShadow } from './createShadow';
 
-import { Indicator, NodeId, DragTarget } from '../interfaces';
+import { Indicator, NodeId, DragTarget, NodeTree } from '../interfaces';
 
 export type DefaultEventHandlersOptions = {
   isMultiSelectEnabled: (e: MouseEvent) => boolean;
@@ -245,7 +246,7 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
       },
       create: (
         el: HTMLElement,
-        userElement: React.ReactElement,
+        userElement: React.ReactElement | (() => NodeTree),
         options?: Partial<CreateHandlerOptions>
       ) => {
         el.setAttribute('draggable', 'true');
@@ -255,9 +256,9 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
           'dragstart',
           (e) => {
             e.craft.stopPropagation();
-            const tree = store.query
-              .parseReactElement(userElement)
-              .toNodeTree();
+            const tree = isValidElement(userElement)
+              ? store.query.parseReactElement(userElement).toNodeTree()
+              : userElement();
 
             const dom = e.currentTarget as HTMLElement;
             this.draggedElementShadow = createShadow(


### PR DESCRIPTION
issue: #316 

To save nodes as templates that can be dragged into the editor, userElement can be of type function that returns NodeTree.

Executed at the start of each drag to generate a new id for each node.

```
connectors.create(
    ref,
    // executed at the start of each drag to generate a new id for each node
    () => {
        const nodeTree = ...;
        const newNodeId = getRandomId();
        ......
        return nodeTree;
    }
  )
```