### PR TITLE
fix: add generic props type for NodeData

### DIFF
--- a/packages/core/src/interfaces/nodes.ts
+++ b/packages/core/src/interfaces/nodes.ts
@@ -23,9 +23,9 @@ export type UserComponent<T = any> = React.ComponentType<T> & {
 export type NodeId = string;
 export type NodeEventTypes = 'selected' | 'dragged' | 'hovered';
 
-export type Node = {
+export type Node<P = any> = {
   id: NodeId;
-  data: NodeData;
+  data: NodeData<P>;
   events: Record<NodeEventTypes, boolean>;
   dom: HTMLElement | null;
   related: Record<string, React.ElementType>;
@@ -42,7 +42,7 @@ export type NodeRules = {
 };
 export type NodeRelated = Record<string, React.ElementType>;
 
-export type NodeData = {
+export type NodeData<P = any> = {
   props: Record<string, any>;
   type: string | React.ElementType;
   name: string;

--- a/packages/core/src/nodes/useInternalNode.ts
+++ b/packages/core/src/nodes/useInternalNode.ts
@@ -7,26 +7,26 @@ import { NodeContext, NodeContextType } from './NodeContext';
 import { useInternalEditor } from '../editor/useInternalEditor';
 import { Node } from '../interfaces';
 
-type internalActions = NodeContextType & {
+type internalActions<P = any> = NodeContextType & {
   inNodeContext: boolean;
   actions: {
-    setProp: (cb: (props: any) => void, throttleRate?: number) => void;
+    setProp: (cb: (props: P) => void, throttleRate?: number) => void;
     setCustom: (cb: (custom: any) => void, throttleRate?: number) => void;
     setHidden: (bool: boolean) => void;
   };
 };
 
 // TODO: Deprecate useInternalNode in favor of useNode
-export type useInternalNodeReturnType<S = null> = S extends null
-  ? internalActions
-  : S & internalActions;
+export type useInternalNodeReturnType<S = null, P = any> = S extends null
+  ? internalActions<P>
+  : S & internalActions<P>;
 export function useInternalNode(): useInternalNodeReturnType;
-export function useInternalNode<S = null>(
-  collect?: (node: Node) => S
-): useInternalNodeReturnType<S>;
-export function useInternalNode<S = null>(
-  collect?: (node: Node) => S
-): useInternalNodeReturnType<S> {
+export function useInternalNode<S = null, P = any>(
+  collect?: (node: Node<P>) => S
+): useInternalNodeReturnType<S, P>;
+export function useInternalNode<S = null, P = any>(
+  collect?: (node: Node<P>) => S
+): useInternalNodeReturnType<S, P> {
   const context = useContext(NodeContext);
   invariant(context, ERROR_USE_NODE_OUTSIDE_OF_EDITOR_CONTEXT);
 


### PR DESCRIPTION
in typescript, we suppose not to use `any`. we can simply add the generic type on Node to make codes better.
ex.
```ts
  const {
    actions: { setProp },
    props,
  } = useNode((node: Node<CraftProgramCollectionProps>) => ({
    props: node.data.props,
  }))
```
`setProps` will be:
```
const setProp: (cb: (props: CraftProgramCollectionProps) => void, throttleRate?: number | undefined) => void
```