### PR TITLE
Fix material-Ui v4 migration warning in the landing example

### DIFF
--- a/examples/landing/components/editor/Toolbar/ToolbarSection.tsx
+++ b/examples/landing/components/editor/Toolbar/ToolbarSection.tsx
@@ -1,8 +1,8 @@
 import { useNode } from '@craftjs/core';
 import {
-  ExpansionPanel,
-  ExpansionPanelDetails,
-  ExpansionPanelSummary,
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Grid,
   Divider,
 } from '@material-ui/core';
@@ -21,7 +21,7 @@ const usePanelStyles = makeStyles((_) => ({
       '&:before': {
         opacity: '1',
       },
-      '& + .MuiExpansionPanel-root:before ': {
+      '& + .MuiAccordion-root:before ': {
         display: 'block',
       },
     },
@@ -50,8 +50,8 @@ export const ToolbarSection = ({ title, props, summary, children }: any) => {
       }, {}),
   }));
   return (
-    <ExpansionPanel classes={panelClasses}>
-      <ExpansionPanelSummary classes={summaryClasses}>
+    <Accordion classes={panelClasses}>
+      <AccordionSummary classes={summaryClasses}>
         <div className="px-6 w-full">
           <Grid container direction="row" alignItems="center" spacing={3}>
             <Grid item xs={4}>
@@ -73,13 +73,13 @@ export const ToolbarSection = ({ title, props, summary, children }: any) => {
             ) : null}
           </Grid>
         </div>
-      </ExpansionPanelSummary>
-      <ExpansionPanelDetails style={{ padding: '0px 24px 20px' }}>
+      </AccordionSummary>
+      <AccordionDetails style={{ padding: '0px 24px 20px' }}>
         <Divider />
         <Grid container spacing={1}>
           {children}
         </Grid>
-      </ExpansionPanelDetails>
-    </ExpansionPanel>
+      </AccordionDetails>
+    </Accordion>
   );
 };


### PR DESCRIPTION
Fix the naming according to https://mui.com/guides/migration-v4/#expansionpanel
Warning message:
![image](https://user-images.githubusercontent.com/17799600/138123292-7a672335-417f-4cca-a744-3390725fa277.png)
