### PR TITLE
Fixes landing page drag unselected nodes

### DIFF
--- a/examples/landing/components/editor/RenderNode.tsx
+++ b/examples/landing/components/editor/RenderNode.tsx
@@ -103,7 +103,7 @@ export const RenderNode = ({ render }) => {
         ? ReactDOM.createPortal(
             <IndicatorDiv
               ref={currentRef}
-              className="px-2 py-2 text-white bg-primary fixed flex items-center"
+              className="fixed flex items-center px-2 py-2 text-white bg-primary"
               style={{
                 left: getPos(dom).left,
                 top: getPos(dom).top,
@@ -112,7 +112,15 @@ export const RenderNode = ({ render }) => {
             >
               <h2 className="flex-1 mr-4">{name}</h2>
               {moveable ? (
-                <Btn className="mr-2 cursor-move" ref={drag}>
+                <Btn
+                  className="mr-2 cursor-move"
+                  ref={(ref) => {
+                    if (id !== ROOT_NODE) {
+                      actions.selectNode(id);
+                    }
+                    drag(ref);
+                  }}
+                >
                   <Move />
                 </Btn>
               ) : null}

--- a/examples/landing/components/editor/RenderNode.tsx
+++ b/examples/landing/components/editor/RenderNode.tsx
@@ -116,7 +116,11 @@ export const RenderNode = ({ render }) => {
                   className="mr-2 cursor-move"
                   ref={drag}
                   onMouseDown={() => {
-                    actions.selectNode(id);
+                    // only select the node if it is not already selected
+                    // otherwise during multiple selection we would lose other the multiple selection nodes
+                    if (!isActive) {
+                      actions.selectNode(id);
+                    }
                   }}
                 >
                   <Move />

--- a/examples/landing/components/editor/RenderNode.tsx
+++ b/examples/landing/components/editor/RenderNode.tsx
@@ -114,11 +114,9 @@ export const RenderNode = ({ render }) => {
               {moveable ? (
                 <Btn
                   className="mr-2 cursor-move"
-                  ref={(ref) => {
-                    if (id !== ROOT_NODE) {
-                      actions.selectNode(id);
-                    }
-                    drag(ref);
+                  ref={drag}
+                  onMouseDown={() => {
+                    actions.selectNode(id);
                   }}
                 >
                   <Move />


### PR DESCRIPTION
This PR fixes #346 by selecting the node before dragging. We select the node by doing a `actions.selectNode` on `onMouseDown`.

Took some commits to also respect multiple selection