### PR TITLE
Select unselected nodes before dragging

### DIFF
--- a/packages/core/src/events/DefaultEventHandlers.ts
+++ b/packages/core/src/events/DefaultEventHandlers.ts
@@ -191,7 +191,22 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
             e.craft.stopPropagation();
 
             const { query, actions } = store;
-            const selectedElementIds = query.getEvent('selected').all();
+
+            let selectedElementIds = query.getEvent('selected').all();
+
+            const isMultiSelect = this.options.isMultiSelectEnabled(e);
+            const isNodeAlreadySelected = this.currentSelectedElementIds.includes(
+              id
+            );
+
+            if (!isNodeAlreadySelected) {
+              if (isMultiSelect) {
+                selectedElementIds = [...selectedElementIds, id];
+              } else {
+                selectedElementIds = [id];
+              }
+              store.actions.setNodeEvent('selected', selectedElementIds);
+            }
 
             actions.setNodeEvent('dragged', selectedElementIds);
 


### PR DESCRIPTION
Fixes #346 and supersedes #347 

Now nodes are selected before dragging if they were not selected before.

Example A)
We have "Button B" currently selected but drag "Button A" without holding the meta key, we only drag "Button A".

https://user-images.githubusercontent.com/2842920/142855260-57438d9c-5ef7-43f5-965d-94980aff1c8a.mov

Example B)
We have "Button B" currently selected, drag "Button A" while holding down the meta key -> we drag both.

https://user-images.githubusercontent.com/2842920/142855401-bf121fbd-93de-44df-95ad-a8e9179c28ac.mov

Example C)
We have no button selected and drag "Button A"

https://user-images.githubusercontent.com/2842920/142855490-70d360a1-9e66-4e5f-9ca6-374cb479f87e.mov

Example D)
We have both Buttons selected and drag them without holding down the meta key.

https://user-images.githubusercontent.com/2842920/142855554-d123445f-ba44-416e-a261-d8a2bda86b4c.mov



 