### PR TITLE
fix(v0.3.x): merge normalize state call

### DIFF
--- a/packages/core/src/store/EditorStore.ts
+++ b/packages/core/src/store/EditorStore.ts
@@ -109,16 +109,19 @@ export class EditorStore extends Store<EditorState> {
           ...accum,
           [actionKey]: (...args) => {
             return this.setState(
-              (state) => ActionMethods(state, this)[actionKey](...args),
+              (state) => {
+                ActionMethods(state, this)[actionKey](...args);
+
+                // TODO: this will be deprecated
+                // Keeping it here until we improve the actions API
+                if (this.config.normalizeNodes) {
+                  return;
+                }
+
+                this.config.normalizeNodes(state, currentState);
+              },
               {
                 onPatch: (patches, inversePatches) => {
-                  // TODO: this will be deprecated
-                  // Keeping it here until we improve the actions API
-                  if (this.config.normalizeNodes) {
-                    this.setState((state) =>
-                      this.config.normalizeNodes(state, currentState)
-                    );
-                  }
                   if (
                     [
                       'setDOM',

--- a/packages/core/src/utils/removeNodeFromEvents.ts
+++ b/packages/core/src/utils/removeNodeFromEvents.ts
@@ -1,11 +1,11 @@
-import { EditorState, NodeId } from '../interfaces';
+import { EditorState, NodeId, EditorEvents } from '../interfaces';
 
-export const removeNodeFromEvents = (state: EditorState, nodeId: NodeId) =>
-  Object.keys(state.events).forEach((key) => {
-    const eventSet = state.events[key];
-    if (eventSet && eventSet.has && eventSet.has(nodeId)) {
-      state.events[key] = new Set(
-        Array.from(eventSet).filter((id) => nodeId !== id)
-      );
+export const removeNodeFromEvents = (state: EditorState, nodeId: NodeId) => {
+  return Object.keys(state.events).forEach((key: keyof EditorEvents) => {
+    if (!state.events[key].has(nodeId)) {
+      return;
     }
+
+    state.events[key].delete(nodeId);
   });
+};

--- a/packages/utils/src/Store/useCollector.tsx
+++ b/packages/utils/src/Store/useCollector.tsx
@@ -6,7 +6,7 @@ export function useCollector<S extends Store, C = null>(
   store: S,
   collector?: (state: StateForStore<S>) => C
 ) {
-  const [collected, setCollected] = useState<any>(
+  const [collected, setCollected] = useState<any>(() =>
     collector ? collector(store.getState()) : ({} as C)
   );
 


### PR DESCRIPTION
Currently a separate `setState` is called in order to perform any normalisation following an Action. 

This PR performs normalisation in the same `setState` call as the Action that was called. 