### PR TITLE
hotfix(v0.3.x): try catch collector values

### DIFF
--- a/examples/landing/components/selectors/Resizer.tsx
+++ b/examples/landing/components/selectors/Resizer.tsx
@@ -1,4 +1,4 @@
-import { useNode, useEditor } from '@craftjs/core';
+import { useNode } from '@craftjs/core';
 import cx from 'classnames';
 import { debounce } from 'debounce';
 import { Resizable } from 're-resizable';
@@ -83,32 +83,23 @@ const Indicators = styled.div<{ bound?: 'row' | 'column' }>`
 
 export const Resizer = ({ propKey, children, ...props }: any) => {
   const {
-    id,
     actions: { setProp },
     connectors: { connect },
     fillSpace,
     nodeWidth,
     nodeHeight,
-    parent,
     active,
     inNodeContext,
+    parentDirection,
+    isRootNode,
   } = useNode((node) => ({
-    parent: node.data.parent,
-    active: node.events.selected,
-    nodeWidth: node.data.props[propKey.width],
-    nodeHeight: node.data.props[propKey.height],
-    fillSpace: node.data.props.fillSpace,
+    active: node.isSelected(),
+    nodeWidth: node.props[propKey.width],
+    nodeHeight: node.props[propKey.height],
+    fillSpace: node.props.fillSpace,
+    parentDirection: !node.isRoot() && node.getParent().props.flexDirection,
+    isRootNode: node.isRoot(),
   }));
-
-  const { isRootNode, parentDirection } = useEditor((state, query) => {
-    return {
-      parentDirection:
-        parent &&
-        state.nodes[parent] &&
-        state.nodes[parent].data.props.flexDirection,
-      isRootNode: query.node(id).isRoot(),
-    };
-  });
 
   const resizable = useRef<Resizable>(null);
   const isResizing = useRef<Boolean>(false);

--- a/packages/layers/src/layers/DefaultLayer/DefaultLayer.tsx
+++ b/packages/layers/src/layers/DefaultLayer/DefaultLayer.tsx
@@ -56,7 +56,8 @@ export const DefaultLayer: React.FC = ({ children }) => {
   }));
   const { hasChildCanvases } = useEditor((state, query) => {
     return {
-      hasChildCanvases: query.node(id).isParentOfTopLevelNodes(),
+      hasChildCanvases:
+        query.node(id) && query.node(id).isParentOfTopLevelNodes(),
     };
   });
 

--- a/packages/layers/src/layers/DefaultLayer/DefaultLayerHeader.tsx
+++ b/packages/layers/src/layers/DefaultLayer/DefaultLayerHeader.tsx
@@ -110,7 +110,7 @@ export const DefaultLayerHeader: React.FC = () => {
     return {
       hidden: state.nodes[id] && state.nodes[id].data.hidden,
       selected,
-      topLevel: query.node(id).isTopLevelCanvas(),
+      topLevel: query.node(id) && query.node(id).isTopLevelCanvas(),
     };
   });
 

--- a/packages/layers/src/layers/DefaultLayer/EditableLayerName.tsx
+++ b/packages/layers/src/layers/DefaultLayer/EditableLayerName.tsx
@@ -9,9 +9,10 @@ export const EditableLayerName = () => {
 
   const { displayName, actions } = useEditor((state) => ({
     displayName:
-      state.nodes[id] && state.nodes[id].data.custom.displayName
+      state.nodes[id] &&
+      (state.nodes[id].data.custom.displayName
         ? state.nodes[id].data.custom.displayName
-        : state.nodes[id].data.displayName,
+        : state.nodes[id].data.displayName),
     hidden: state.nodes[id] && state.nodes[id].data.hidden,
   }));
 


### PR DESCRIPTION
Wraps collectors in a try-catch block to prevent site from crashing when accessing a deleted Node's properties