### PR TITLE
fix: linked nodes history

### DIFF
--- a/packages/core/src/nodes/Element.tsx
+++ b/packages/core/src/nodes/Element.tsx
@@ -67,7 +67,11 @@ export function Element<T extends React.ElementType>({
         const tree = query.parseReactElementAsNodeTree(linkedElement);
 
         linkedNodeId = tree.rootNodeId;
-        actions.history.ignore().addLinkedNodeFromTree(tree, nodeId, id);
+        actions.history
+          .merge({
+            ignoreIfNoPreviousRecords: true,
+          })
+          .addLinkedNodeFromTree(tree, nodeId, id);
       }
 
       setLinkedNodeId(linkedNodeId);

--- a/packages/core/src/nodes/NodeElement.tsx
+++ b/packages/core/src/nodes/NodeElement.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { NodeProvider } from './NodeContext';
 
+import { useEditor } from '../hooks';
 import { NodeId } from '../interfaces';
 import { RenderNodeToElement } from '../render/RenderNode';
 
@@ -11,6 +12,14 @@ export type NodeElementProps = {
 };
 
 export const NodeElement: React.FC<NodeElementProps> = ({ id, render }) => {
+  const { exists } = useEditor((state) => ({
+    exists: !!state.node(id),
+  }));
+
+  if (!exists) {
+    return null;
+  }
+
   return (
     <NodeProvider id={id}>
       <RenderNodeToElement render={render} />

--- a/packages/core/src/store/EditorStore.ts
+++ b/packages/core/src/store/EditorStore.ts
@@ -1,4 +1,9 @@
-import { Store, History, ERROR_RESOLVER_NOT_AN_OBJECT } from '@craftjs/utils';
+import {
+  Store,
+  History,
+  HistoryMergeOpts,
+  ERROR_RESOLVER_NOT_AN_OBJECT,
+} from '@craftjs/utils';
 import invariant from 'tiny-invariant';
 
 import { ActionMethods } from './actions';
@@ -162,9 +167,9 @@ export class EditorStore extends Store<EditorState> {
         getBaseActions((patch, inversePatch) =>
           this.history.throttleAdd(patch, inversePatch, rate)
         ),
-      merge: () =>
+      merge: (opts?: HistoryMergeOpts) =>
         getBaseActions((patch, inversePatch) =>
-          this.history.merge(patch, inversePatch)
+          this.history.merge(patch, inversePatch, opts)
         ),
     };
 

--- a/packages/utils/src/History.ts
+++ b/packages/utils/src/History.ts
@@ -15,6 +15,10 @@ export const HISTORY_ACTIONS = {
   CLEAR: 'HISTORY_CLEAR',
 };
 
+export type HistoryMergeOpts = {
+  ignoreIfNoPreviousRecords: boolean;
+};
+
 export class History {
   timeline: Timeline = [];
   pointer = -1;
@@ -65,7 +69,11 @@ export class History {
     this.add(patches, inversePatches);
   }
 
-  merge(patches: Patch[], inversePatches: Patch[]) {
+  merge(
+    patches: Patch[],
+    inversePatches: Patch[],
+    opts?: Partial<HistoryMergeOpts>
+  ) {
     if (patches.length === 0 && inversePatches.length === 0) {
       return;
     }
@@ -82,6 +90,12 @@ export class History {
         patches: [...currPatches, ...patches],
         inversePatches: [...inversePatches, ...currInversePatches],
       };
+      return;
+    }
+
+    // There's no previous history records in the timeline, and therefore nothing to merge with
+    // If ignoreIfNoPreviousRecords=true, then we will simply discard the current changes from the timeline
+    if (opts && opts.ignoreIfNoPreviousRecords) {
       return;
     }
 


### PR DESCRIPTION
Currently, when we create new Linked Nodes when `<Element />` mounts, the action is not tracked in the history stack. Thus, when the user hits "Undo", the Linked Node won't be deleted.

This PR fixes the issue by replacing `actions.history.ignore().addLinkedNodeTree` with `actions.history.merge().addLinkedNodeTree` which merges the `addLinkedNodeTree` action with the previous history record (if any). 

