### PR TITLE
fix: remove redundant "}" of the image url

### DIFF
--- a/site/src/components/Image.js
+++ b/site/src/components/Image.js
@@ -7,7 +7,7 @@ export const Image = ({ img, src }) => {
     siteConfig: { baseUrl },
   } = context;
 
-  const imageSrc = src || `${baseUrl}img/${img}}`;
+  const imageSrc = src || `${baseUrl}img/${img}`;
 
   return (
     <div className="img-wrapper">


### PR DESCRIPTION
now, all images in [documentation](https://craft.js.org/docs/guides/basic-tutorial) are broken by redundant `%7D` in the end.

example:
- https://craft.js.org/img/tutorial/interface.png%7D
