### PR TITLE
feat: add events.draggedOver

### DIFF
--- a/examples/basic/components/user/Card.js
+++ b/examples/basic/components/user/Card.js
@@ -1,4 +1,4 @@
-import { Element, useNode } from '@craftjs/core';
+import { Element, useNode, useEditor } from '@craftjs/core';
 import React from 'react';
 
 import { Button } from './Button';
@@ -58,8 +58,25 @@ CardBottom.craft = {
 };
 
 export const Card = ({ background, padding = 20, ...props }) => {
+  const { id } = useNode();
+  const { isBeingDraggedOver } = useEditor((state, query) => {
+    return {
+      // we consider the card as being dragged over if one of its ancestors (CardTop or CardBottom)
+      // is being dragged over. Attention: This only works because neither CardTop nor CardBottom accept other canvases (Card or Container)
+      // as their children.
+      //
+      // Tip: for a more complex scenario have a look at the Container
+      isBeingDraggedOver: query.getDraggedOverNodes().has(id),
+    };
+  });
+
   return (
-    <Container {...props} background={background} padding={padding}>
+    <Container
+      {...props}
+      background={background}
+      padding={padding}
+      outline={isBeingDraggedOver ? '2px dashed blue' : undefined}
+    >
       <Element canvas id="text" is={CardTop} data-cy="card-top">
         <Text text="Only texts" fontSize={20} data-cy="card-top-text-1" />
         <Text

--- a/examples/basic/components/user/Container.js
+++ b/examples/basic/components/user/Container.js
@@ -1,18 +1,57 @@
-import { useNode } from '@craftjs/core';
+import { useNode, useEditor } from '@craftjs/core';
 import { Slider } from '@material-ui/core';
 import { Paper, FormControl, FormLabel } from '@material-ui/core';
 import ColorPicker from 'material-ui-color-picker';
 import React from 'react';
 
-export const Container = ({ background, padding, children, ...props }) => {
+export const Container = ({
+  background,
+  padding,
+  children,
+  outline,
+  ...props
+}) => {
   const {
     connectors: { connect, drag },
+    id: containerNodeId,
   } = useNode();
+
+  // we want to render an outline around this Container when the user drags over it
+  // if we have several nested containers we only want to render an outline around the Container the user is able to drop into.
+  //
+  // Since we know that the nodes are ordered descending by their depth in the node tree we know that we can use a "for ... of" loop to go through
+  // the nodes by their depth. So we need to find the first Canvas and only highlight it when it has the same id as our current Container
+  const { isBeingDraggedOver } = useEditor((state, query) => {
+    // we have to look through all the ancestors (and the element itself) the user currently drags over
+    let isBeingDraggedOver = false;
+
+    for (const nodeId of query.getDraggedOverNodes()) {
+      // we are looking for the first canvas element
+      if (query.node(nodeId).isCanvas()) {
+        // if the id of first canvas element is the same as this Container's id we know that the user is dragging over this Container
+        if (nodeId === containerNodeId) {
+          isBeingDraggedOver = true;
+        }
+        // Since we are only interested in the first Canvas, we break out of the loop
+        break;
+      }
+    }
+
+    return {
+      isBeingDraggedOver,
+    };
+  });
+
   return (
     <Paper
       {...props}
       ref={(ref) => connect(drag(ref))}
-      style={{ margin: '5px 0', background, padding: `${padding}px` }}
+      style={{
+        margin: '5px 0',
+        background,
+        padding: `${padding}px`,
+        outline: outline || isBeingDraggedOver ? '2px blue dashed' : undefined,
+      }}
     >
       {children}
     </Paper>

--- a/packages/core/src/editor/actions.ts
+++ b/packages/core/src/editor/actions.ts
@@ -303,6 +303,7 @@ const Methods = (
       this.setNodeEvent('selected', null);
       this.setNodeEvent('hovered', null);
       this.setNodeEvent('dragged', null);
+      this.setNodeEvent('draggedOver', null);
       this.setIndicator(null);
     },
 

--- a/packages/core/src/editor/query.tsx
+++ b/packages/core/src/editor/query.tsx
@@ -118,6 +118,39 @@ export function QueryMethods(state: EditorState) {
     },
 
     /**
+     * Helper to get ids of the nodes the user is currently dragging a node over
+     *
+     * @example
+     * ```
+     * <div data-nodeid="ROOT">
+     *   <div data-nodeid="node-1-1">
+     *      <div data-nodeid="node-2-1">A</div>
+     *      <div data-nodeid="node-2-2">B</div>
+     *   </div>
+     *   <div data-nodeid="node-1-2">C</div>
+     * </div>
+     * ```
+     *
+     * Let's use the code above as an example. Imagine a user would drag a node over the div with content A. The list that getDraggedOverNodes will return
+     * would be `['node-2-1', 'node-1-1', 'ROOT']`
+     *
+     * @returns The list of the node ids the user is currently dragging a node over. Ordered "descending" by the depth in the node tree.
+     * The lowest node the "ROOT" will be last element and deepest element (the one we are dragging over) will be first. In between we have the ancestors of the first element
+     * ordered by their depth accordingly.
+     */
+    getDraggedOverNodes(): Set<NodeId> {
+      const draggedOverNodeId = Array.from(state.events.draggedOver)[0];
+      if (draggedOverNodeId) {
+        return new Set([
+          draggedOverNodeId,
+          ..._().node(draggedOverNodeId).ancestors(),
+        ]);
+      } else {
+        return new Set();
+      }
+    },
+
+    /**
      * Get the current Editor options
      */
     getOptions(): Options {

--- a/packages/core/src/editor/store.tsx
+++ b/packages/core/src/editor/store.tsx
@@ -16,6 +16,7 @@ export const editorInitialState: EditorState = {
     dragged: new Set<NodeId>(),
     selected: new Set<NodeId>(),
     hovered: new Set<NodeId>(),
+    draggedOver: new Set<NodeId>(),
   },
   indicator: null,
   handlers: null,

--- a/packages/core/src/events/DefaultEventHandlers.ts
+++ b/packages/core/src/events/DefaultEventHandlers.ts
@@ -168,6 +168,8 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
           el,
           'dragenter',
           (e) => {
+            store.actions.setNodeEvent('draggedOver', targetId);
+
             e.craft.stopPropagation();
             e.preventDefault();
           }
@@ -358,6 +360,7 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
 
     store.actions.setIndicator(null);
     store.actions.setNodeEvent('dragged', null);
+    store.actions.setNodeEvent('draggedOver', null);
     this.positioner.cleanup();
 
     this.positioner = null;

--- a/packages/core/src/interfaces/nodes.ts
+++ b/packages/core/src/interfaces/nodes.ts
@@ -21,7 +21,7 @@ export type UserComponent<T = any> = React.ComponentType<T> & {
 };
 
 export type NodeId = string;
-export type NodeEventTypes = 'selected' | 'dragged' | 'hovered';
+export type NodeEventTypes = 'selected' | 'dragged' | 'hovered' | 'draggedOver';
 
 export type Node = {
   id: NodeId;


### PR DESCRIPTION
Hi there,

PR #186 is long overdue but I couldn't get it to run because of some stupid git merge conflicts.  So here we go again.

Here is the old text:
This PR adds draggedOver to the events. It's almost the same as #37 but targets the next branch and the new EventHandlers, which also gives us a cleaner API. (#37 will be obsolete - #186 will also be obsolete ).

Since the new EventHandlers introduced a Set as the store for the EventHandlers, we can now store not only the id of the node we are dragging over, but all of its ancestors, too.

I also updated the Basic example with two different examples on how to make use of the new API.

Closes #28
Closes #183

Supersedes #186
Supersedes #37
