### PR TITLE
feat(v0.3.x): add history event listener

### DIFF
--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -7,4 +7,4 @@ export * from './events';
 export * from './store';
 export * from './utils/testHelpers';
 export * from './utils/types';
-export { ROOT_NODE } from '@craftjs/utils';
+export { ROOT_NODE, History, HISTORY_OPERATION } from '@craftjs/utils';

--- a/packages/utils/src/History.ts
+++ b/packages/utils/src/History.ts
@@ -6,14 +6,14 @@ type Timeline = Array<{
   timestamp: number;
 }>;
 
-export const HISTORY_ACTIONS = {
-  UNDO: 'HISTORY_UNDO',
-  REDO: 'HISTORY_REDO',
-  THROTTLE: 'HISTORY_THROTTLE',
-  IGNORE: 'HISTORY_IGNORE',
-  MERGE: 'HISTORY_MERGE',
-  CLEAR: 'HISTORY_CLEAR',
-};
+export enum HISTORY_OPERATION {
+  UNDO = 'HISTORY_UNDO',
+  REDO = 'HISTORY_REDO',
+  CLEAR = 'HISTORY_CLEAR',
+  ADD = 'HISTORY_ADD',
+}
+
+export type HistoryListener = (op: HISTORY_OPERATION) => void;
 
 export type HistoryMergeOpts = {
   ignoreIfNoPreviousRecords: boolean;
@@ -22,6 +22,8 @@ export type HistoryMergeOpts = {
 export class History {
   timeline: Timeline = [];
   pointer = -1;
+
+  listeners: Set<HistoryListener> = new Set();
 
   add(patches: Patch[], inversePatches: Patch[]) {
     if (patches.length === 0 && inversePatches.length === 0) {
@@ -35,6 +37,8 @@ export class History {
       inversePatches,
       timestamp: Date.now(),
     };
+
+    this.notify(HISTORY_OPERATION.ADD);
   }
 
   throttleAdd(
@@ -105,6 +109,8 @@ export class History {
   clear() {
     this.timeline = [];
     this.pointer = -1;
+
+    this.notify(HISTORY_OPERATION.CLEAR);
   }
 
   canUndo() {
@@ -122,6 +128,9 @@ export class History {
 
     const { inversePatches } = this.timeline[this.pointer];
     this.pointer = this.pointer - 1;
+
+    this.notify(HISTORY_OPERATION.UNDO);
+
     return applyPatches(state, inversePatches);
   }
 
@@ -132,6 +141,19 @@ export class History {
 
     this.pointer = this.pointer + 1;
     const { patches } = this.timeline[this.pointer];
+
+    this.notify(HISTORY_OPERATION.REDO);
+
     return applyPatches(state, patches);
+  }
+
+  listen(listener: HistoryListener) {
+    this.listeners.add(listener);
+
+    return () => this.listeners.delete(listener);
+  }
+
+  private notify(op: HISTORY_OPERATION) {
+    this.listeners.forEach((listener) => listener(op));
   }
 }


### PR DESCRIPTION
This PR adds the ability to listen for when a History operation is performed. This comes in handy if for example - you're building your own History manager and need a way to know when there's a undo/redo record available in Craft:

```tsx
import { EditorStory, HISTORY_OPERATION } from '@craftjs/core';

class YourCustomHistoryManager {
    changes: [];

   constructor(store: EditorStore) {
     store.history.listen((op) => {
        if ( op === HISTORY_OPERATION.ADD ) {
             this.track({ isCraft: true });
        }
     });
   }

  track(change){
      this.changes.push(change);
  }

  undo(change) {
      if ( change.isCraft ) {
          this.store.actions.history.undo();
          return;
      }

     // handle other types of changes in your App
  }

 redo(change) {...}
}