### PR TITLE
fix: add children prop required by react 18

### DIFF
--- a/packages/core/src/interfaces/editor.ts
+++ b/packages/core/src/interfaces/editor.ts
@@ -9,6 +9,7 @@ import { useInternalEditorReturnType } from '../editor/useInternalEditor';
 import { CoreEventHandlers } from '../events';
 
 export type Options = {
+  children?: React.ReactNode;
   onRender: React.ComponentType<{ render: React.ReactElement }>;
   onBeforeMoveEnd: (
     targetNode: Node,

--- a/packages/core/src/render/Frame.tsx
+++ b/packages/core/src/render/Frame.tsx
@@ -6,6 +6,7 @@ import { SerializedNodes } from '../interfaces';
 import { NodeElement } from '../nodes/NodeElement';
 
 export type Frame = {
+  children?: React.ReactNode;
   json?: string;
   data?: string | SerializedNodes;
 };


### PR DESCRIPTION
React 18 requires that the `children` prop be defined explicitly (https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-typescript-definitions)