### PR TITLE
Updated `isMultiSelectEnabled` to support ctrl key on windows

### DIFF
--- a/packages/core/src/editor/store.tsx
+++ b/packages/core/src/editor/store.tsx
@@ -32,7 +32,8 @@ export const editorInitialState: EditorState = {
     handlers: (store) =>
       new DefaultEventHandlers({
         store,
-        isMultiSelectEnabled: (e: MouseEvent) => !!e.metaKey,
+        isMultiSelectEnabled: (e: MouseEvent) =>
+          navigator.userAgent.includes('Mac') ? !!e.metaKey : !!e.ctrlKey,
       }),
     normalizeNodes: () => {},
   },

--- a/site/docs/guides/basic-tutorial.md
+++ b/site/docs/guides/basic-tutorial.md
@@ -926,7 +926,7 @@ const { currentlySelectedId } = useEditor((state) => {
 })
 ```
 
-> Note: state.events.selected is of type `Set<string>`. This is because in the case of multi-select, it's possible for the user to select multiple Nodes by holding down the `<meta>` key.
+> Note: state.events.selected is of type `Set<string>`. This is because in the case of multi-select, it's possible for the user to select multiple Nodes by holding down the `<meta>` key (Mac) or `<ctrl>` key (Windows).
 
 Now, let's replace the placeholder text fields in our Settings Panel with the `settings` Related Component:
 


### PR DESCRIPTION
Hello - while testing beta, I found that the use of `metaKey` for multi-selection does not work well on Windows. Generally the commands for metaKey on mac are equivalent to the ctrl key on windows, so I added a platform check using `navigator.userAgent`. 