### PR TITLE
Fix/kzn 6901 remove columns broken

### DIFF
--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -1,4 +1,3 @@
-src
 rollup.config.js
 tsconfig.json
 nodemon.json

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,8 +18,8 @@
   "author": "Prev Wong <prevwong@gmail.com>",
   "homepage": "https://github.com/prevwong/craft.js/",
   "license": "MIT",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
+  "main": "./src/index.tsx",
+  "module": "./src/index.tsx",
   "types": "./lib/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/core/src/events/DefaultEventHandlers.ts
+++ b/packages/core/src/events/DefaultEventHandlers.ts
@@ -211,15 +211,17 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
 
             actions.setNodeEvent('dragged', selectedElementIds);
 
-            const selectedDOMs = selectedElementIds.map(
-              (id) => query.node(id).get().dom
-            );
+            // Kizen customization: do not show the shadowed element when
+            // dragging existing items on the canvas.
+            // const selectedDOMs = selectedElementIds.map(
+            //   (id) => query.node(id).get().dom
+            // );
 
-            this.draggedElementShadow = createShadow(
-              e,
-              selectedDOMs,
-              DefaultEventHandlers.forceSingleDragShadow
-            );
+            // this.draggedElementShadow = createShadow(
+            //   e,
+            //   selectedDOMs,
+            //   DefaultEventHandlers.forceSingleDragShadow
+            // );
 
             this.dragTarget = {
               type: 'existing',

--- a/packages/core/src/nodes/Element.tsx
+++ b/packages/core/src/nodes/Element.tsx
@@ -81,5 +81,5 @@ export function Element<T extends React.ElementType>({
     }
   });
 
-  return linkedNodeId ? <NodeElement id={linkedNodeId} /> : null;
+  return linkedNodeId ? <NodeElement id={linkedNodeId} {...elementProps} /> : null;
 }

--- a/packages/core/src/nodes/NodeElement.tsx
+++ b/packages/core/src/nodes/NodeElement.tsx
@@ -12,10 +12,10 @@ export type NodeElementProps = {
 
 export const NodeElement: React.FC<React.PropsWithChildren<
   NodeElementProps
->> = ({ id, render }) => {
+>> = ({ id, render, ...rest }) => {
   return (
     <NodeProvider id={id}>
-      <RenderNodeToElement render={render} />
+      <RenderNodeToElement render={render} {...rest} />
     </NodeProvider>
   );
 };

--- a/packages/core/src/render/DefaultRender.tsx
+++ b/packages/core/src/render/DefaultRender.tsx
@@ -6,7 +6,7 @@ import { NodeId } from '../interfaces';
 import { NodeElement } from '../nodes/NodeElement';
 import { useInternalNode } from '../nodes/useInternalNode';
 
-export const DefaultRender = () => {
+export const DefaultRender = (p) => {
   const { type, props, nodes, hydrationTimestamp } = useInternalNode(
     (node) => ({
       type: node.data.type,
@@ -29,7 +29,7 @@ export const DefaultRender = () => {
       );
     }
 
-    const render = React.createElement(type, props, children);
+    const render = React.createElement(type, { ...props, ...p }, children);
 
     if (typeof type == 'string') {
       return <SimpleElement render={render} />;
@@ -37,5 +37,5 @@ export const DefaultRender = () => {
 
     return render;
     // eslint-disable-next-line  react-hooks/exhaustive-deps
-  }, [type, props, hydrationTimestamp, nodes]);
+  }, [type, props, p, hydrationTimestamp, nodes]);
 };

--- a/packages/core/src/render/RenderNode.tsx
+++ b/packages/core/src/render/RenderNode.tsx
@@ -10,7 +10,7 @@ type RenderNodeToElementType = {
 };
 export const RenderNodeToElement: React.FC<React.PropsWithChildren<
   RenderNodeToElementType
->> = ({ render }) => {
+>> = ({ render, ...rest }) => {
   const { hidden } = useInternalNode((node) => ({
     hidden: node.data.hidden,
   }));
@@ -24,5 +24,5 @@ export const RenderNodeToElement: React.FC<React.PropsWithChildren<
     return null;
   }
 
-  return React.createElement(onRender, { render: render || <DefaultRender /> });
+  return React.createElement(onRender, { render: render || <DefaultRender {...rest} /> });
 };


### PR DESCRIPTION
## Goal
The latest version of craft broke our usage of `<Element is={Cell} {...props} />`. The additional props passed to Element are not available in the user component specified in the `is` prop. This broke our remove column buttons for empty page builder cells.