### PR TITLE
hotfix: optional enabled prop

### DIFF
--- a/packages/core/src/editor/Editor.tsx
+++ b/packages/core/src/editor/Editor.tsx
@@ -72,11 +72,14 @@ export const Editor: React.FC<React.PropsWithChildren<Partial<Options>>> = ({
 
   // sync enabled prop with editor store options
   useEffect(() => {
-    if (!context) {
+    if (!context || !options) {
       return;
     }
 
-    if (context.query.getOptions().enabled === options.enabled) {
+    if (
+      options.enabled === undefined ||
+      context.query.getOptions().enabled === options.enabled
+    ) {
       return;
     }
 


### PR DESCRIPTION
Fix regression caused in #501 where `enabled` option is incorrectly set to undefined if the option was not explicitly specified in the `<Editor />` component

Closes #508  