### PR TITLE
Added duplicate functionality to RenderNode.

### DIFF
--- a/examples/landing/components/editor/RenderNode.tsx
+++ b/examples/landing/components/editor/RenderNode.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 
 import ArrowUp from '../../public/icons/arrow-up.svg';
 import Delete from '../../public/icons/delete.svg';
+import Duplicate from '../../public/icons/duplicate.svg';
 import Move from '../../public/icons/move.svg';
 
 const IndicatorDiv = styled.div`
@@ -13,12 +14,6 @@ const IndicatorDiv = styled.div`
   margin-top: -29px;
   font-size: 12px;
   line-height: 12px;
-
-  svg {
-    fill: #fff;
-    width: 15px;
-    height: 15px;
-  }
 `;
 
 const Btn = styled.a`
@@ -30,6 +25,29 @@ const Btn = styled.a`
     position: relative;
     top: -50%;
     left: -50%;
+  }
+
+  svg {
+    fill: #fff;
+    width: 15px;
+    height: 15px;
+  }
+`;
+
+const DuplicateBtn = styled.a`
+  padding: 0 0px;
+  opacity: 0.9;
+  display: flex;
+  align-items: center;
+  > div {
+    position: relative;
+    top: -50%;
+    left: -50%;
+  }
+
+  svg {
+    width: 15px;
+    height: 15px;
   }
 `;
 
@@ -47,6 +65,7 @@ export const RenderNode = ({ render }) => {
     deletable,
     connectors: { drag },
     parent,
+    isCanvas,
   } = useNode((node) => ({
     isHover: node.events.hovered,
     dom: node.dom,
@@ -55,6 +74,7 @@ export const RenderNode = ({ render }) => {
     deletable: query.node(node.id).isDeletable(),
     parent: node.data.parent,
     props: node.data.props,
+    isCanvas: query.node(node.id).isCanvas(),
   }));
 
   const currentRef = useRef<HTMLDivElement>();
@@ -128,7 +148,7 @@ export const RenderNode = ({ render }) => {
               )}
               {deletable ? (
                 <Btn
-                  className="cursor-pointer"
+                  className="mr-2 cursor-pointer"
                   onMouseDown={(e: React.MouseEvent) => {
                     e.stopPropagation();
                     actions.delete(id);
@@ -136,6 +156,22 @@ export const RenderNode = ({ render }) => {
                 >
                   <Delete />
                 </Btn>
+              ) : null}
+              {!isCanvas ? (
+                <DuplicateBtn
+                  className="cursor-pointer"
+                  onMouseDown={() => {
+                    const {
+                      data: { type, props },
+                    } = query.node(id).get();
+                    actions.add(
+                      query.createNode(React.createElement(type, props)),
+                      parent
+                    );
+                  }}
+                >
+                  <Duplicate />
+                </DuplicateBtn>
               ) : null}
             </IndicatorDiv>,
             document.querySelector('.page-container')

--- a/examples/landing/public/icons/duplicate.svg
+++ b/examples/landing/public/icons/duplicate.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-copy"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>


### PR DESCRIPTION
Added a duplicate button beside the delete button in the landing example for more functionality within the editor. This also provides developers with more examples on how they can use craft.js to meet there needs.

<img width="491" alt="Screen Shot 2023-04-27 at 3 20 37 PM" src="https://user-images.githubusercontent.com/48871601/235004797-1f182146-832c-44e7-88ef-88805d6d879b.png">
