### PR TITLE
Resolve issue with indicator width:

### DIFF
--- a/packages/layers/src/events/RenderLayerIndicator.tsx
+++ b/packages/layers/src/events/RenderLayerIndicator.tsx
@@ -50,7 +50,7 @@ export const RenderLayerIndicator: React.FC<any> = ({ children }) => {
         return {
           top,
           left: headingPos.left,
-          width: pos.width - headingPos.left,
+          width: pos.width + pos.left - headingPos.left,
           height: 2,
           borderWidth: 0,
           background: color,


### PR DESCRIPTION
Resolves issue where the indicator would be a negative width if the `Layers` plugin was not placed on the left-hand side of the screen. This was due to `getBoundingClientRect()` calculating the `headingPos` realtive to the viewport. This change accounts for the `Layers` component placed anywhere in the viewport by adding back in the postion of the layer parent item.

See screenshot for real-world implementation that caused the indicator to the inccorect width due to the `Layers` component being used elsewhere in the viewport:
![Screenshot 2023-06-20 at 4 05 45 PM](https://github.com/prevwong/craft.js/assets/21250577/61feae43-6dc1-4925-9c11-cee84ba9db25)
