### PR TITLE
`fix:` custom handlers not accepting

### DIFF
--- a/packages/core/src/editor/store.tsx
+++ b/packages/core/src/editor/store.tsx
@@ -101,6 +101,7 @@ export const useEditorStore = (
     ActionMethodsWithConfig,
     {
       ...editorInitialState,
+      ...(options.handlers ? { handlers: options.handlers } : {}),
       options: {
         ...editorInitialState.options,
         ...options,


### PR DESCRIPTION
- Fix the issue of providing custom `DefaultEventHandlers` not working.

https://github.com/prevwong/craft.js/issues/545