### PR TITLE
fix: Custom id passing forward from Parse Node From JSX

### DIFF
--- a/packages/core/src/utils/parseNodeFromJSX.tsx
+++ b/packages/core/src/utils/parseNodeFromJSX.tsx
@@ -18,6 +18,7 @@ export function parseNodeFromJSX(
 
   return createNode(
     {
+      id: element.props?.id,
       data: {
         type: actualType,
         props: { ...element.props },


### PR DESCRIPTION
- Fix: Custom id passing forward from Parse Node From JSX
[549](https://github.com/prevwong/craft.js/issues/549)