### PR TITLE
(layers) Fix for dropping nodes into empty container

### DIFF
--- a/packages/layers/src/events/LayerHandlers.ts
+++ b/packages/layers/src/events/LayerHandlers.ts
@@ -51,11 +51,7 @@ export class LayerHandlers extends DerivedCoreEventHandlers<{
 
             const { indicator, currentCanvasHovered } = LayerHandlers.events;
 
-            if (
-              currentCanvasHovered &&
-              indicator &&
-              currentCanvasHovered.data.nodes
-            ) {
+            if (currentCanvasHovered && indicator) {
               const heading = this.getLayer(
                 currentCanvasHovered.id
               ).headingDom.getBoundingClientRect();
@@ -70,6 +66,17 @@ export class LayerHandlers extends DerivedCoreEventHandlers<{
                   ];
 
                 if (!currNode) {
+                  // If the currentCanvasHovered has no child nodes, then we place the indicator as the first child
+                  LayerHandlers.events.indicator = {
+                    ...indicator,
+                    placement: {
+                      ...indicator.placement,
+                      index: 0,
+                      where: 'before',
+                      parent: currentCanvasHovered,
+                    },
+                    onCanvas: true,
+                  };
                   return;
                 }
 


### PR DESCRIPTION
Fixes #562

This PR resolves an issue in the layers package where a node was not able to be placed within a container using the layers drag and drop interface when the accepting container had no children