### PR TITLE
fix: onNodesChange now updates its state correctly

### DIFF
--- a/packages/core/src/editor/Editor.tsx
+++ b/packages/core/src/editor/Editor.tsx
@@ -76,6 +76,17 @@ export const Editor: React.FC<React.PropsWithChildren<Partial<Options>>> = ({
       return;
     }
 
+
+     if (
+      options.onNodesChange !== undefined &&
+      options.onNodesChange !== context.query.getOptions().onNodesChange
+    ) {
+      context.actions.setOptions((editorOptions) => {
+        editorOptions.onNodesChange = options.onNodesChange;
+      });
+    }
+
+    
     if (
       options.enabled === undefined ||
       context.query.getOptions().enabled === options.enabled
@@ -86,7 +97,7 @@ export const Editor: React.FC<React.PropsWithChildren<Partial<Options>>> = ({
     context.actions.setOptions((editorOptions) => {
       editorOptions.enabled = options.enabled;
     });
-  }, [context, options.enabled]);
+  }, [context, options.enabled, options.onNodesChange]);
 
   useEffect(() => {
     context.subscribe(


### PR DESCRIPTION
There is a problem with onNodesChange using state from the initialization of <Editor/> component 

This fixes it at now it updates the value correctly: 

Old code example: 

```ts
 console.log(mode) //1st call: firstMode, 2nd call: secondMode
  return (
    <Editor
      enabled={true}
      onNodesChange={(query) => {
        console.log(mode); //1st call: firstMode, 2nd call: firstMode (always firstMode no matter what)
      
      }}
      resolver={{ ... }}
    >
      {children}
    </Editor>
  );

```

New code example: 
```ts
 console.log(mode) //1st call: firstMode, 2nd call: secondMode
  return (
    <Editor
      enabled={true}
      onNodesChange={(query) => {
        console.log(mode); //1st call: firstMode, 2nd call: secondMode
      
      }}
      resolver={{ ... }}
    >
      {children}
    </Editor>
  );

```

Screenshot of working example: 

<img width="982" alt="image" src="https://github.com/prevwong/craft.js/assets/82416181/16856ce0-5c30-444a-92fe-98f18370fe08">


Code of this example screenshot:
 ```ts
const [count, setCount] = useState(0);

  return (
    <>
      <Editor
        resolver={{
          Item: Item,
          Toolbox: Toolbox,
        }}
        onNodesChange={() => {
          console.log('nodes changed, current count state: ', count);
        }}
      >
...
```