### PR TITLE
fix: orphaned nodes when parsing from Frame's children in strict mode

### DIFF
--- a/.changeset/old-chicken-lay.md
+++ b/.changeset/old-chicken-lay.md
@@ -1,0 +1,5 @@
+---
+'@craftjs/core': patch
+---
+
+Fix orphaned nodes when parsing from Frame's children

--- a/.changeset/old-chicken-lay.md
+++ b/.changeset/old-chicken-lay.md
@@ -2,4 +2,4 @@
 '@craftjs/core': patch
 ---
 
-Fix orphaned nodes when parsing from Frame's children
+Fix orphaned nodes when parsing from Frame's children in strict mode


### PR DESCRIPTION
Closes #473 