### PR TITLE
chore(doc): add an example for overriding Editor event handlers

### DIFF
--- a/site/docs/api/Editor.md
+++ b/site/docs/api/Editor.md
@@ -116,9 +116,7 @@ import {
   NodeId
 } from '@craftjs/core'
 
-type CustomEventHandlersOptions = {};
-
-class CustomEventHandlers extends DefaultEventHandlers<CustomEventHandlersOptions> {
+class CustomEventHandlers extends DefaultEventHandlers {
   handlers() {
     const defaultHandlers = super.handlers()
 
@@ -152,7 +150,7 @@ const App = () => {
         new CustomEventHandlers({ store, isMultiSelectEnabled: () => false })
       }
     >
-      ..
+      ...
     </Editor>
   )
 }

--- a/site/docs/api/Editor.md
+++ b/site/docs/api/Editor.md
@@ -134,8 +134,8 @@ class CustomEventHandlers extends DefaultEventHandlers {
         })
 
         return () => {
-          unbindDefaultHoverHandler()
-          unbindMouseleave()
+          unbindDefaultHoverHandler();
+          unbindMouseleave();
         }
       }
     }

--- a/site/docs/api/Editor.md
+++ b/site/docs/api/Editor.md
@@ -107,7 +107,7 @@ const App = () => {
 ### Override default event handlers
 Customize how the default event handlers are handled
 
-```tsx {9-40,46-48}
+```tsx {9-35,41-43}
 import {
   DefaultEventHandlers,
   DefaultEventHandlersOptions,

--- a/site/docs/api/Editor.md
+++ b/site/docs/api/Editor.md
@@ -17,7 +17,8 @@ Creates the context that stores the editor state.
   ["enabled?", "boolean", "Optional. If set to false, all editing capabilities will be disabled"],
   ["indicator?", 'Record<"success" | "error", String>', "Optional. The colour to use for the drop indicator. The colour set in 'success' will be used when the indicator shows a droppable location; otherwise the colour set in 'error' will be used."],
   ["onRender?", "React.ComponentType<{element: React.ReactElement}>", "Optional. Specify a custom component to render every User Element in the editor."],
-  ["onNodesChange?", "(query: QueryMethods) => void", "Optional. A callback method when the values of any of the nodes in the state changes"]
+  ["onNodesChange?", "(query: QueryMethods) => void", "Optional. A callback method when the values of any of the nodes in the state changes"],
+  ["handlers?", "(store: EditorStore) => CoreEventHandlers", "Optional. Override the default event handlers with your own logic."]
 ]} />
 
 
@@ -95,6 +96,66 @@ const App = () => {
         // save to server
         axios.post('/saveJSON', { json });
       }}
+    >
+      ..
+    </Editor>
+  )
+}
+```
+
+
+### Override default event handlers
+Customize how the default event handlers are handled
+
+```tsx {9-40,46-48}
+import {
+  DefaultEventHandlers,
+  DefaultEventHandlersOptions,
+  Editor,
+  EditorStore,
+  NodeId
+} from '@craftjs/core'
+
+class CustomEventHandlers extends DefaultEventHandlers {
+  isMultiSelectEnabled: (e: MouseEvent) => boolean
+
+  constructor(options: DefaultEventHandlersOptions & { store: EditorStore }) {
+    super(options)
+    this.isMultiSelectEnabled = options.isMultiSelectEnabled
+  }
+
+  handlers() {
+    const defaultHandlers = super.handlers()
+
+    return {
+      ...defaultHandlers,
+      // Customize the hover event handler
+      hover: (el: HTMLElement, id: NodeId) => {
+        const unbindMouseover = defaultHandlers.hover(el, id)
+
+        // Track when the mouse leaves a node and remove the hovered state
+        const unbindMouseleave = this.addCraftEventListener(el, 'mouseleave', (e) => {
+          e.craft.stopPropagation()
+          this.options.store.actions.setNodeEvent('hovered', '')
+          console.log(`mouseleave node ${id}`)
+        })
+
+        return () => {
+          unbindMouseover()
+          unbindMouseleave()
+        }
+      }
+    }
+  }
+}
+
+const App = () => {
+  return (
+    <Editor
+      // Use your own event handlers
+      handlers={(store) =>
+        new CustomEventHandlers({ store, isMultiSelectEnabled: () => false })
+      }
     >
       ..
     </Editor>

--- a/site/docs/api/Editor.md
+++ b/site/docs/api/Editor.md
@@ -116,14 +116,9 @@ import {
   NodeId
 } from '@craftjs/core'
 
-class CustomEventHandlers extends DefaultEventHandlers {
-  isMultiSelectEnabled: (e: MouseEvent) => boolean
+type CustomEventHandlersOptions = {};
 
-  constructor(options: DefaultEventHandlersOptions & { store: EditorStore }) {
-    super(options)
-    this.isMultiSelectEnabled = options.isMultiSelectEnabled
-  }
-
+class CustomEventHandlers extends DefaultEventHandlers<CustomEventHandlersOptions> {
   handlers() {
     const defaultHandlers = super.handlers()
 
@@ -131,7 +126,7 @@ class CustomEventHandlers extends DefaultEventHandlers {
       ...defaultHandlers,
       // Customize the hover event handler
       hover: (el: HTMLElement, id: NodeId) => {
-        const unbindMouseover = defaultHandlers.hover(el, id)
+        const unbindDefaultHoverHandler = defaultHandlers.hover(el, id)
 
         // Track when the mouse leaves a node and remove the hovered state
         const unbindMouseleave = this.addCraftEventListener(el, 'mouseleave', (e) => {
@@ -141,7 +136,7 @@ class CustomEventHandlers extends DefaultEventHandlers {
         })
 
         return () => {
-          unbindMouseover()
+          unbindDefaultHoverHandler()
           unbindMouseleave()
         }
       }


### PR DESCRIPTION
Added an example to the docs of how users can override the default Editor event handlers.
Note: Unlike the other examples, the code does include TypeScript types, let me know if you want the example to be JSX instead.