### PR TITLE
feat: remove node hovered state on mouseleave event

### DIFF
--- a/.changeset/rude-bees-deliver.md
+++ b/.changeset/rude-bees-deliver.md
@@ -2,4 +2,4 @@
 '@craftjs/core': patch
 ---
 
-Added mouseleave event to default hover event handler that removes hovered state when triggered
+Remove node hovered state on mouseleave event

--- a/.changeset/rude-bees-deliver.md
+++ b/.changeset/rude-bees-deliver.md
@@ -1,5 +1,5 @@
 ---
-'@craftjs/core': minor
+'@craftjs/core': patch
 ---
 
 Added mouseleave event to default hover event handler that removes hovered state when triggered

--- a/.changeset/rude-bees-deliver.md
+++ b/.changeset/rude-bees-deliver.md
@@ -1,0 +1,5 @@
+---
+'@craftjs/core': minor
+---
+
+Added mouseleave event to default hover event handler that removes hovered state when triggered

--- a/packages/core/src/editor/Editor.tsx
+++ b/packages/core/src/editor/Editor.tsx
@@ -79,7 +79,7 @@ export const Editor: React.FC<React.PropsWithChildren<Partial<Options>>> = ({
     }
 
     if (
-      options.enabled === undefined ||
+      options?.enabled === undefined ||
       context.query.getOptions().enabled === options.enabled
     ) {
       return;
@@ -88,7 +88,7 @@ export const Editor: React.FC<React.PropsWithChildren<Partial<Options>>> = ({
     context.actions.setOptions((editorOptions) => {
       editorOptions.enabled = options.enabled;
     });
-  }, [context, options.enabled]);
+  }, [context, options?.enabled]);
 
   useEffect(() => {
     context.subscribe(

--- a/packages/core/src/editor/Editor.tsx
+++ b/packages/core/src/editor/Editor.tsx
@@ -79,7 +79,7 @@ export const Editor: React.FC<React.PropsWithChildren<Partial<Options>>> = ({
     }
 
     if (
-      options?.enabled === undefined ||
+      options.enabled === undefined ||
       context.query.getOptions().enabled === options.enabled
     ) {
       return;
@@ -88,7 +88,7 @@ export const Editor: React.FC<React.PropsWithChildren<Partial<Options>>> = ({
     context.actions.setOptions((editorOptions) => {
       editorOptions.enabled = options.enabled;
     });
-  }, [context, options?.enabled]);
+  }, [context, options.enabled]);
 
   useEffect(() => {
     context.subscribe(

--- a/packages/core/src/events/DefaultEventHandlers.ts
+++ b/packages/core/src/events/DefaultEventHandlers.ts
@@ -139,7 +139,7 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
           'mouseleave',
           (e) => {
             e.craft.stopPropagation();
-            store.actions.setNodeEvent('hovered', '');
+            store.actions.setNodeEvent('hovered', null);
           }
         );
 

--- a/packages/core/src/events/DefaultEventHandlers.ts
+++ b/packages/core/src/events/DefaultEventHandlers.ts
@@ -134,8 +134,18 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
           }
         );
 
+        const unbindMouseleave = this.addCraftEventListener(
+          el,
+          'mouseleave',
+          (e) => {
+            e.craft.stopPropagation();
+            store.actions.setNodeEvent('hovered', '');
+          }
+        );
+
         return () => {
           unbindMouseover();
+          unbindMouseleave();
         };
       },
       drop: (el: HTMLElement, targetId: NodeId) => {


### PR DESCRIPTION
Added `mouseleave` to default hover event handler, the `hovered` state gets removed when this is triggered.

Previously, if you wanted to removed the `hovered` state, you'd have to add something like
`ref={(ref: HTMLDivElement) => connectors.select(connectors.hover(ref, ''), '')}`
to a parent container to deselect/remove the hover state when the mouse pointer clicks/is outside of a node.

Also updated the `useEffect` in `packages/core/src/editor/Editor.tsx` due to lint error.
