### PR TITLE
Allow adding custom metadata to the `UserComponent` that can be brought into `Node`

### DIFF
--- a/.changeset/stupid-onions-mate.md
+++ b/.changeset/stupid-onions-mate.md
@@ -1,5 +1,5 @@
 ---
-'@craftjs/core': minor
+'@craftjs/core': patch
 ---
 
 Add custom metadata to the UserComponent that can be brought into Node

--- a/.changeset/stupid-onions-mate.md
+++ b/.changeset/stupid-onions-mate.md
@@ -1,0 +1,5 @@
+---
+'@craftjs/core': minor
+---
+
+Add custom metadata to the UserComponent that can be brought into Node

--- a/packages/core/src/interfaces/nodes.ts
+++ b/packages/core/src/interfaces/nodes.ts
@@ -9,6 +9,7 @@ export type UserComponentConfig<T> = {
   related: Partial<NodeRelated>;
   props: Partial<T>;
   custom: Record<string, any>;
+  customMetadata: Record<string, any>;
   isCanvas: boolean;
 
   // TODO: Deprecate
@@ -26,6 +27,7 @@ export type NodeEventTypes = 'selected' | 'dragged' | 'hovered';
 export type Node = {
   id: NodeId;
   data: NodeData;
+  customMetadata: Record<string, any>;
   events: Record<NodeEventTypes, boolean>;
   dom: HTMLElement | null;
   related: Record<string, React.ElementType>;

--- a/packages/core/src/utils/createNode.ts
+++ b/packages/core/src/utils/createNode.ts
@@ -37,6 +37,7 @@ export function createNode(
       linkedNodes: {},
       ...newNode.data,
     },
+    customMetadata: {},
     related: {},
     events: {
       selected: false,
@@ -135,6 +136,10 @@ export function createNode(
             React.createElement(userComponentConfig.related[comp], props)
           );
       });
+    }
+
+    if (userComponentConfig.customMetadata) {
+      node.customMetadata = userComponentConfig.customMetadata;
     }
   }
 


### PR DESCRIPTION
Related discussion: https://github.com/prevwong/craft.js/discussions/576

After adding this feature, whenever we get the `Node`, we will also get the custom metadata of the user component. So we were able to automate some of the actions that we previously had to perform manually.
This can bring more configurability to the whole framework.
