### PR TITLE
fix: defaultLayerHeader chevron rotation

### DIFF
--- a/.changeset/blue-goats-cheer.md
+++ b/.changeset/blue-goats-cheer.md
@@ -1,0 +1,5 @@
+---
+"@craftjs/layers": patch
+---
+
+Improve defaultLayerHeader chevron rotation

--- a/packages/layers/src/layers/DefaultLayer/DefaultLayerHeader.tsx
+++ b/packages/layers/src/layers/DefaultLayer/DefaultLayerHeader.tsx
@@ -42,12 +42,14 @@ const StyledDiv = styled.div<{ depth: number; selected: boolean }>`
 const Expand = styled.a<{ expanded: boolean }>`
   width: 8px;
   height: 8px;
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform-origin: center;
   transition: 0.4s cubic-bezier(0.19, 1, 0.22, 1);
   transform: rotate(${(props) => (props.expanded ? 180 : 0)}deg);
   opacity: 0.7;
   cursor: pointer;
-  transform-origin: 60% center;
 `;
 
 const Hide = styled.a<{ selected: boolean; isHidden: boolean }>`


### PR DESCRIPTION
The current animation of the chevron misplaces it in the layout and looks somewhat broken. 

This PR addresses this by centering the svg in the link container and setting the transform-origin to its direct center.

**Before:**

https://github.com/prevwong/craft.js/assets/45669613/e7877f1d-230b-4f53-be34-ac69dfb12f08

**After:**

https://github.com/prevwong/craft.js/assets/45669613/27584cd3-8e7c-4770-b792-f24dda109e10


