### PR TITLE
fix: <Frame> docs bad json provided to data prop

### DIFF
--- a/site/docs/api/Frame.md
+++ b/site/docs/api/Frame.md
@@ -65,7 +65,7 @@ const App = () => {
       <Editor>
         <h2>My Page Editor</h2>
         <Frame
-          data='{"ROOT":{"type":"div","isCanvas":true,"props":{},"parent":null,"displayName":"div","custom":{},"nodes":["node-sdiwzXkvQ","node-rGFDi0G6m","node-yNBLMy5Oj"]},"node-sdiwzXkvQ":{"type":{"resolvedName":"Card"},"props":{},"parent":"ROOT","displayName":"Card","custom":{},"_childCanvas":{"main":"canvas-_EEw_eBD_","second":"canvas-lE4Ni9oIn"}}'
+          data='{"ROOT":{"type":"div","isCanvas":true,"props":{},"parent":null,"displayName":"div","custom":{},"nodes":["node-sdiwzXkvQ","node-rGFDi0G6m","node-yNBLMy5Oj"]},"node-sdiwzXkvQ":{"type":{"resolvedName":"Card"},"props":{},"parent":"ROOT","displayName":"Card","custom":{},"_childCanvas":{"main":"canvas-_EEw_eBD_","second":"canvas-lE4Ni9oIn"}}}'
         > 
           <Element is={Container} canvas> // defines the Root Node
             <h2>Drag me around</h2>


### PR DESCRIPTION
Fixes the Frame docs [Loading from serialized nodes](https://craft.js.org/docs/api/frame#loading-from-serialized-nodes) section. Now the example JSON provided in the data prop is bad formatted needs one more curly brace at the end. This curly brace is added on the PR, now the Frame docs example works well. 