### PR TITLE
Allow external context injection to the Editor

### DIFF
--- a/packages/core/src/editor/store.tsx
+++ b/packages/core/src/editor/store.tsx
@@ -35,6 +35,7 @@ export const editorInitialState: EditorState = {
         isMultiSelectEnabled: (e: MouseEvent) => !!e.metaKey,
       }),
     normalizeNodes: () => {},
+    context: null,
   },
 };
 

--- a/packages/core/src/interfaces/editor.ts
+++ b/packages/core/src/interfaces/editor.ts
@@ -34,6 +34,7 @@ export type Options = {
     >,
     query: QueryCallbacksFor<typeof QueryMethods>
   ) => void;
+  context: EditorStore;
 };
 
 export type Resolver = Record<string, string | React.ElementType>;


### PR DESCRIPTION
Now the @craftjs/core Editor component accepts an external context injection for advanced use cases when external management of the state is necessary. 

Previously, you needed to be inside the context provider to have access to the store. Now, since you can pass it as prop, you can initialise the context outside and have access to it. However, the component works as usual if you do not pass the context prop.