### PR TITLE
add rollup cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lib
 .vscode
 .idea
 build
+.rollup.cache
 
 .DS_Store
 cypress/videos/*


### PR DESCRIPTION
Update `.gitignore` settings to exclude the Rollup cache folder