### PR TITLE
 feat: allow layers to utilise CoreEventHandler mouseleave options

### DIFF
--- a/.changeset/smooth-elephants-clean.md
+++ b/.changeset/smooth-elephants-clean.md
@@ -1,0 +1,6 @@
+---
+'@craftjs/core': patch
+'@craftjs/layers': patch
+---
+
+Use removeHoverOnMouseleave option for layers package

--- a/packages/core/src/events/CoreEventHandlers.ts
+++ b/packages/core/src/events/CoreEventHandlers.ts
@@ -8,7 +8,7 @@ export interface CreateHandlerOptions {
 }
 
 export class CoreEventHandlers<O = {}> extends EventHandlers<
-  { store: EditorStore } & O
+  { store: EditorStore; removeHoverOnMouseleave: boolean } & O
 > {
   handlers() {
     return {

--- a/packages/core/src/events/DefaultEventHandlers.ts
+++ b/packages/core/src/events/DefaultEventHandlers.ts
@@ -138,10 +138,14 @@ export class DefaultEventHandlers<O = {}> extends CoreEventHandlers<
         let unbindMouseleave: (() => void) | null = null;
 
         if (this.options.removeHoverOnMouseleave) {
-          this.addCraftEventListener(el, 'mouseleave', (e) => {
-            e.craft.stopPropagation();
-            store.actions.setNodeEvent('hovered', null);
-          });
+          unbindMouseleave = this.addCraftEventListener(
+            el,
+            'mouseleave',
+            (e) => {
+              e.craft.stopPropagation();
+              store.actions.setNodeEvent('hovered', null);
+            }
+          );
         }
 
         return () => {

--- a/packages/layers/src/events/LayerHandlers.ts
+++ b/packages/layers/src/events/LayerHandlers.ts
@@ -42,6 +42,19 @@ export class LayerHandlers extends DerivedCoreEventHandlers<{
           }
         );
 
+        let unbindMouseleave: (() => void) | null = null;
+
+        if (this.derived.options.removeHoverOnMouseleave) {
+          unbindMouseleave = this.addCraftEventListener(
+            el,
+            'mouseleave',
+            (e) => {
+              e.craft.stopPropagation();
+              layerStore.actions.setLayerEvent('hovered', null);
+            }
+          );
+        }
+
         const unbindDragOver = this.addCraftEventListener(
           el,
           'dragover',
@@ -174,6 +187,12 @@ export class LayerHandlers extends DerivedCoreEventHandlers<{
           unbindMouseOver();
           unbindDragOver();
           unbindDragEnter();
+
+          if (!unbindMouseleave) {
+            return;
+          }
+
+          unbindMouseleave();
         };
       },
       layerHeader: (el: HTMLElement, layerId: NodeId) => {


### PR DESCRIPTION
I noticed that `removeHoverOnMouseleave` wasn't working in the Layers, to get this working I basically just piggy-backed on the same option that is used in the core package and applied the relevant listener.

```ts
if (this.derived.options.removeHoverOnMouseleave) {
  unbindMouseleave = this.addCraftEventListener(
    el,
    'mouseleave',
    (e) => {
      e.craft.stopPropagation();
      layerStore.actions.setLayerEvent('hovered', null);
    }
  );
}
```

Not 100% sure on the change of adding the option to the type of the [CoreEventHandlers]( https://github.com/itsbjoern/craft.js/blob/4a20cff03a911a062a8bdf3fa523672bcc450d61/packages/core/src/events/CoreEventHandlers.ts#L11) but as far as I can tell that resolves any type issues on the derived handler type.

Also, as part of it I snuck in a small fix, as far as I can tell the mouseleave listener was never cleaned up in core because it was actually never assigned, so I added this as part of this PR. 