### PR TITLE
Fix typo in core concepts docs, user-components.md

### DIFF
--- a/site/docs/concepts/user-components.md
+++ b/site/docs/concepts/user-components.md
@@ -156,7 +156,7 @@ Text.craft = {
 
 
 ## Related Components
-What happens if you need to design some component to complement our  user component? For instance, if we were planning on building a Toolbar somewhere in our page editor, we would like the Toolbar to display a bunch of text inputs to allow the user the edit the currently selected component. It would be great if we could retrieve a specific component that has all the relevant inputs for the user to edit the currently selected component.
+What happens if you need to design some component to complement our  user component? For instance, if we were planning on building a Toolbar somewhere in our page editor, we would like the Toolbar to display a bunch of text inputs to allow the user to edit the currently selected component. It would be great if we could retrieve a specific component that has all the relevant inputs for the user to edit the currently selected component.
 
 
 This is where related components become useful. These components share the same corresponding `Node` as the actual user component, hence the `useNode` hook that we have been using all this while will be made available to these components as well. 


### PR DESCRIPTION
Fix typo.
Change "allow the user the edit the currently" to "allow the user to edit the currently"