### PR TITLE
fix: correctly serialize null props

### DIFF
--- a/.changeset/few-icons-repeat.md
+++ b/.changeset/few-icons-repeat.md
@@ -1,0 +1,5 @@
+---
+'@craftjs/core': patch
+---
+
+Correctly serialize null props

--- a/packages/core/src/utils/serializeNode.tsx
+++ b/packages/core/src/utils/serializeNode.tsx
@@ -20,11 +20,13 @@ export const serializeComp = (
   props = Object.keys(props).reduce((result: Record<string, any>, key) => {
     const prop = props[key];
 
-    if (prop === undefined || prop === null || typeof prop === 'function') {
+    if (prop === undefined || typeof prop === 'function') {
       return result;
     }
 
-    if (key === 'children' && typeof prop !== 'string') {
+    if (prop === null) {
+      result[key] = null;
+    } else if (key === 'children' && typeof prop !== 'string') {
       result[key] = Children.map(prop, (child) => {
         if (typeof child === 'string') {
           return child;


### PR DESCRIPTION
Say a `Component` has a prop called `color` which can be `string | null | undefined` and it also has `Component.defaultProps.color` set to `'red'`. If this component is added to the editor with `color=null` it will be rendered with the prop value as `null` (it would, correctly, not use the default prop value), But before this change, if you then serialized and deserialized the component, it would have unexpectedly switched to rendering with the prop `color = Component.defaultProps.color = red`.
