### PR TITLE
fix: Deprecated: element.ref

### DIFF
--- a/.changeset/fluffy-pumas-smile.md
+++ b/.changeset/fluffy-pumas-smile.md
@@ -1,0 +1,5 @@
+---
+'@craftjs/utils': patch
+---
+
+Accessing element.ref is no longer supported. ref is now a regular prop.

--- a/packages/utils/src/EventHandlers/wrapConnectorHooks.tsx
+++ b/packages/utils/src/EventHandlers/wrapConnectorHooks.tsx
@@ -19,7 +19,7 @@ export function cloneWithRef(
   element: any,
   newRef: any
 ): React.ReactElement<any> {
-  const previousRef = element.props.ref;
+  const previousRef = element.props.ref || element.ref;
   invariant(
     typeof previousRef !== 'string',
     'Cannot connect to an element with an existing string ref. ' +

--- a/packages/utils/src/EventHandlers/wrapConnectorHooks.tsx
+++ b/packages/utils/src/EventHandlers/wrapConnectorHooks.tsx
@@ -19,7 +19,7 @@ export function cloneWithRef(
   element: any,
   newRef: any
 ): React.ReactElement<any> {
-  const previousRef = element.ref;
+  const previousRef = element.props.ref;
   invariant(
     typeof previousRef !== 'string',
     'Cannot connect to an element with an existing string ref. ' +


### PR DESCRIPTION
Accessing element.ref is no longer supported. ref is now a regular prop. 

Update to address the issue. 